### PR TITLE
Return 'str' type instead of 'graphene.String' as type annotation

### DIFF
--- a/graphene_plugin.py
+++ b/graphene_plugin.py
@@ -16,6 +16,7 @@ GRAPHENE_ENUM_NAME = 'graphene.types.enum.Enum'
 GRAPHENE_LIST_NAME = 'graphene.types.structures.List'
 GRAPHENE_NONNULL_NAME = 'graphene.types.structures.NonNull'
 GRAPHENE_OBJECTTYPE_NAME = 'graphene.types.objecttype.ObjectType'
+GRAPHENE_STRING_NAME = 'graphene.types.scalars.String'
 
 
 @dataclass
@@ -150,7 +151,9 @@ def get_python_type_from_graphene_type( # pylint: disable=too-many-branches,too-
                 ),
                 non_null,
             )
-        return graphene_type.callee.name
+        # This looks like a call to a scalar type, e.g. String().
+        # Setting the type to the callee allows it to be evaluated correctly by the next check.
+        graphene_type = graphene_type.callee
 
     if (
         hasattr(graphene_type, 'node')  \

--- a/graphene_plugin.py
+++ b/graphene_plugin.py
@@ -16,7 +16,6 @@ GRAPHENE_ENUM_NAME = 'graphene.types.enum.Enum'
 GRAPHENE_LIST_NAME = 'graphene.types.structures.List'
 GRAPHENE_NONNULL_NAME = 'graphene.types.structures.NonNull'
 GRAPHENE_OBJECTTYPE_NAME = 'graphene.types.objecttype.ObjectType'
-GRAPHENE_STRING_NAME = 'graphene.types.scalars.String'
 
 
 @dataclass

--- a/test/test-data/unit/graphene_plugin.test
+++ b/test/test-data/unit/graphene_plugin.test
@@ -754,7 +754,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_resolver_with_scalar_type_is_correct]
 from graphene import ObjectType, Field, ResolveInfo, String
-from graphql import ResolveInfo
+from typing import Optional
 
 class A:
     name: str
@@ -762,7 +762,7 @@ class A:
 class TestQuery(ObjectType):
     name = Field(A, name=String())
 
-    def resolve_user(self, info: ResolveInfo, name: Optional[str]) -> None:
+    def resolve_name(self, info: ResolveInfo, name: Optional[str]) -> None:
         return None
 
 [out]

--- a/test/test-data/unit/graphene_plugin.test
+++ b/test/test-data/unit/graphene_plugin.test
@@ -750,3 +750,20 @@ class Person(ObjectType[PersonModel]):
 [out]
 main:14: error: Resolver returns type Union[builtins.str, None], expected type builtins.str
 Found 1 error in 1 file (checked 1 source file)
+
+
+[case test_resolver_with_scalar_type_is_correct]
+from graphene import ObjectType, Field, ResolveInfo, String
+from graphql import ResolveInfo
+
+class A:
+    name: str
+
+class TestQuery(ObjectType):
+    name = Field(A, name=String())
+
+    def resolve_user(self, info: ResolveInfo, name: Optional[str]) -> None:
+        return None
+
+[out]
+Success: no issues found in 1 source file


### PR DESCRIPTION
Hi,

I recently ran into the following code:

```python
import graphene
from graphql import ResolveInfo

class User:
    uid = "Test123"

class Query(graphene.ObjectType):
    user = graphene.Field(User, uid=graphene.String())

    def resolve_user(self, info: ResolveInfo, uid: str) -> None:
        return None
```

But with graphene-stubs mypy fails on this code:

```
test.py:11: error: Parameter "uid" has type str, expected type String
Found 1 error in 1 file (checked 2 source files)
```

However this code is completely valid, `uid` is a `str` here and not `graphene.String`. With the commit in this PR this passes without any problems. If there is any feedback or if you want this done in another way please say something! :)