### PR TITLE
Add support for type-checking the resolver's "previous" argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.mypy_cache
 *.pyc
+
+# IDE configs
+.vscode

--- a/README.md
+++ b/README.md
@@ -14,6 +14,39 @@ Include the plugin in your mypy.ini file:
 plugins = graphene_plugin
 ```
 
+If you want to use the generic version of `ObjectType` then you have to call `patch_object_type()` at the entry point of your application, **before defining any `ObjectType` sub-classes**:
+```python
+from graphene_plugin import patch_object_type
+# Have to patch before defining an `ObjectType` sub-classes, OR importing any modules that define
+# `ObjectType` sub-classes.
+patch_object_type()
+
+
+from graphene import ObjectType, Field, String, ResolveInfo
+
+
+class PersonModel:
+    first_name: str
+    last_name: str
+
+
+class AnimalModel:
+    species: str
+
+
+class Person(ObjectType[PersonModel]):
+    first_name = Field(String, required=True)
+    last_name = Field(String, required=True)
+
+    @staticmethod
+    def resolve_first_name(person: PersonModel, _: ResolveInfo) -> str:
+        return person.first_name
+
+    @staticmethod
+    def resolve_last_name(person: AnimalModel, _: ResolveInfo) -> str:  # fails
+        return person.species
+```
+
 ## Plugin Details
 Because of the implementation and patterns used by Graphene, there are many cases where types are being declared and correspond to arguments used in resolvers, but it's hard for mypy to understand the correlation between them. Because of this, a plugin has been added that does nothing but throw additional errors when types don't seem to match up.
 

--- a/graphene-stubs/types/objecttype.pyi
+++ b/graphene-stubs/types/objecttype.pyi
@@ -2,7 +2,10 @@ from .base import BaseOptions as BaseOptions, BaseType as BaseType
 from .field import Field as Field
 from .interface import Interface as Interface
 from .utils import yank_fields_from_attrs as yank_fields_from_attrs
-from typing import Any, Dict, Iterable, Optional, Type
+from typing import Any, Dict, Iterable, Optional, Type, TypeVar, Generic
+
+
+RT = TypeVar('RT')
 
 
 class ObjectTypeOptions(BaseOptions):
@@ -10,7 +13,7 @@ class ObjectTypeOptions(BaseOptions):
     interfaces: Iterable[Type[Interface]] = ...
 
 
-class ObjectType(BaseType):
+class ObjectType(Generic[RT], BaseType):
     @classmethod
     def __init_subclass_with_meta__( # type: ignore[override]
         cls,

--- a/graphene_plugin.py
+++ b/graphene_plugin.py
@@ -1,10 +1,10 @@
 # pylint: disable=no-name-in-module
 from dataclasses import dataclass
-from typing import Optional, Callable, Type, List, Union
+from typing import Optional, Callable, Type as TypeOf, List, Union, Any
 
-# from mypy.sametypes import is_same_type # TODO: Use this to compare types themselves instead of string representations
+from graphene import ObjectType
 from mypy.plugin import Plugin, ClassDefContext
-from mypy.types import AnyType, CallableType, UnboundType, Instance
+from mypy.types import AnyType, CallableType, UnboundType, Instance, TypeOfAny, Type, NoneType, UnionType
 from mypy.nodes import AssignmentStmt, Decorator, CallExpr, Argument, TypeInfo, FuncDef, EllipsisExpr, StrExpr, \
     Statement, ClassDef, SymbolNode, TupleExpr
 
@@ -14,70 +14,80 @@ GRAPHENE_ENUM_META_NAME = 'graphene.types.enum.EnumMeta'
 GRAPHENE_ENUM_NAME = 'graphene.types.enum.Enum'
 GRAPHENE_LIST_NAME = 'graphene.types.structures.List'
 GRAPHENE_NONNULL_NAME = 'graphene.types.structures.NonNull'
+GRAPHENE_OBJECTTYPE_NAME = 'graphene.types.objecttype.ObjectType'
 
 
 @dataclass
 class ArgumentNode:
     name: str
-    type_name: Optional[str]
+    type: Type
     context: Argument
 
     def __eq__(self, other: object) -> bool:
-        return self.name == other.name  # type: ignore[attr-defined]
+        if not isinstance(other, ArgumentNode):
+            return False
+        return self.name == other.name
 
     def __ne__(self, other: object) -> bool:
-        return self.name != other.name  # type: ignore[attr-defined]
+        return not (self == other)
 
 
 @dataclass
 class TypeNodeInfo:
     name: str
-    return_type_name: Optional[str]
+    return_type: Type
     arguments: List[ArgumentNode]
     context: Union[FuncDef, AssignmentStmt, Optional[SymbolNode]]
 
     def __eq__(self, other: object) -> bool:
-        return self.name == other.name  # type: ignore[attr-defined]
+        if not isinstance(other, TypeNodeInfo):
+            return False
+        return self.name == other.name
 
     def __ne__(self, other: object) -> bool:
-        return self.name != other.name  # type: ignore[attr-defined]
+        return not (self == other)
 
 
-def create_resolver_type(resolver_node: Union[Decorator, FuncDef]) -> 'TypeNodeInfo':
+def create_resolver_type(ctx: ClassDefContext, resolver_node: Union[Decorator, FuncDef]) -> 'TypeNodeInfo':
     name = resolver_node.name[len(RESOLVER_PREFIX):]  # Chop off the beginning of the name for easier matching later
     if isinstance(resolver_node, FuncDef):
         func_def = resolver_node
     if isinstance(resolver_node, Decorator):
         func_def = resolver_node.func
-    uncleaned_return_type = str(func_def.type.ret_type)  # type: ignore[attr-defined, union-attr]
-    return_type_name = uncleaned_return_type.replace('?', '') if func_def.type else None
+    return_type = (
+        ctx.api.anal_type(func_def.type.ret_type)  # type: ignore[attr-defined, union-attr]
+        if func_def.type.ret_type  # type: ignore[attr-defined, union-attr]
+        else None
+    )
+    return_type = return_type or AnyType(TypeOfAny.unannotated)
     argument_list: List['ArgumentNode'] = []
     for argument_node in func_def.arguments:
-        # TODO: Fix the ListType hack somehow.
-        type_name = str(argument_node.type_annotation
-                        ).replace('?', '').replace('ListType', 'List') if argument_node.type_annotation else None
+        argument_type = ctx.api.anal_type(argument_node.type_annotation) if argument_node.type_annotation else None
+        argument_type = argument_type or AnyType(TypeOfAny.unannotated)
         arg_name = argument_node.variable.name
-        argument_list.append(ArgumentNode(name=arg_name, type_name=type_name, context=argument_node))
-    return TypeNodeInfo(name=name, return_type_name=return_type_name, arguments=argument_list, context=func_def)
+        argument_list.append(ArgumentNode(name=arg_name, type=argument_type, context=argument_node))
+    return TypeNodeInfo(name=name, return_type=return_type, arguments=argument_list, context=func_def)
 
 
-def wrap_in_nonnull(type_string: str, non_null: bool) -> str:
-    if non_null or type_string == 'Any':
-        return type_string
-    return f'Optional[{type_string}]'
+def wrap_in_nonnull(python_type: Optional[Type], non_null: bool) -> Optional[Type]:
+    if not python_type or isinstance(python_type, AnyType) or non_null:
+        return python_type
+
+    return UnionType((python_type, NoneType()))
 
 
-def wrap_in_list(type_string: str) -> str:
-    if type_string == 'Any':
-        return type_string
-    return f'List[{type_string}]'
+def wrap_in_list(ctx: ClassDefContext, python_type: Optional[Type]) -> Optional[Type]:
+    if not python_type or isinstance(python_type, AnyType):
+        return python_type
+    return ctx.api.named_type('list', args=[python_type])
 
 
-def get_type_string_from_graphene_type( # pylint: disable=too-many-branches,too-many-return-statements
+def get_python_type_from_graphene_type( # pylint: disable=too-many-branches,too-many-return-statements
+    ctx: ClassDefContext,
     graphene_types: List[TypeInfo],
     arg_names: Optional[List[str]] = None,
     non_null: bool = False,
-) -> str:
+) -> Type:
     if arg_names is None:
         arg_names = []
 
@@ -100,7 +110,7 @@ def get_type_string_from_graphene_type( # pylint: disable=too-many-branches,too-
 
     graphene_type = graphene_types[0]
     if isinstance(graphene_type, StrExpr):
-        return 'Any'  # TODO: Look up the name of graphene_type.value with the api?
+        return AnyType(TypeOfAny.explicit)  # TODO: Look up the name of graphene_type.value with the api?
     # if isinstance(graphene_type, NameExpr):
     #     graphene_type = graphene_type.node
 
@@ -108,13 +118,16 @@ def get_type_string_from_graphene_type( # pylint: disable=too-many-branches,too-
         # This appears to be a graphene type instatiation.
         if not hasattr(graphene_type, 'callee'):
             # TODO: Figure out the None case (starargs?) AND check this is still happening
-            return 'Any'  # TODO: Improve this by using actual types
+            return AnyType(TypeOfAny.explicit)  # TODO: Improve this by using actual types
         if graphene_type.callee.fullname == GRAPHENE_ARGUMENT_NAME:
-            return get_type_string_from_graphene_type(graphene_type.args, graphene_type.arg_names)
+            return get_python_type_from_graphene_type(ctx, graphene_type.args, graphene_type.arg_names)
         if graphene_type.callee.fullname == GRAPHENE_NONNULL_NAME:
-            return get_type_string_from_graphene_type(graphene_type.args, non_null=True)
+            return get_python_type_from_graphene_type(ctx, graphene_type.args, non_null=True)
         if graphene_type.callee.fullname == GRAPHENE_LIST_NAME:
-            return wrap_in_nonnull(wrap_in_list(get_type_string_from_graphene_type(graphene_type.args)), non_null)
+            return wrap_in_nonnull(
+                wrap_in_list(ctx, get_python_type_from_graphene_type(ctx, graphene_type.args)),
+                non_null,
+            )
         return graphene_type.callee.name
 
     if (
@@ -136,33 +149,34 @@ def get_type_string_from_graphene_type( # pylint: disable=too-many-branches,too-
                 # return_type_name = current_type.ret_type.name
             else:
                 # I don't know what this is, let's just return Any.
-                return 'Any'
+                return AnyType(TypeOfAny.explicit)
 
+        return_type: Optional[Type] = None
         if isinstance(current_type, CallableType):
             if isinstance(current_type.ret_type, AnyType):
-                return 'Any'
+                return AnyType(TypeOfAny.explicit)
             if isinstance(current_type.ret_type, Instance):
-                return_type_name = current_type.ret_type.type.name
+                return_type = current_type.ret_type
             elif isinstance(current_type.ret_type, UnboundType):
-                return_type_name = current_type.ret_type.name  # type: ignore[attr-defined]
+                return_type = ctx.api.anal_type(current_type.ret_type)  # type: ignore[attr-defined]
         elif current_type.is_type_obj():
-            return_type_name = current_type.type_object().name
+            return_type = Instance(current_type.type_object(), args=[])
 
     elif hasattr(graphene_type, 'node') and graphene_type.node is not None:  # type: ignore[attr-defined]
         # Check for Enum types.
         graphene_type_node = graphene_type.node  # type: ignore[attr-defined]
         if hasattr(graphene_type_node, 'bases') and \
         GRAPHENE_ENUM_NAME in [base.type.fullname for base in graphene_type_node.bases]:
-            return_type_name = 'str'
+            return_type = ctx.api.named_type('str')
         else:
-            return 'Any'
+            return AnyType(TypeOfAny.explicit)
     else:
         # TODO: Come up with better fallback behavior.
-        return 'Any'
-    return wrap_in_nonnull(return_type_name, non_null)
+        return AnyType(TypeOfAny.explicit)
+    return wrap_in_nonnull(return_type, non_null) or AnyType(TypeOfAny.unannotated)
 
 
-def create_attribute_type(attribute_node: AssignmentStmt) -> Optional['TypeNodeInfo']:
+def create_attribute_type(ctx: ClassDefContext, attribute_node: AssignmentStmt) -> Optional['TypeNodeInfo']:
     # Collect type info about an  attribute on graphene ObjectType classes,
     # e.g. `attribute = Field(String, match_cookie=Argument(List(NonNull(Float))))`
     if isinstance(attribute_node.rvalue, EllipsisExpr):
@@ -180,7 +194,7 @@ def create_attribute_type(attribute_node: AssignmentStmt) -> Optional['TypeNodeI
         return None
 
     argument_node_names = attribute_node.rvalue.arg_names  # type: ignore[attr-defined]
-    return_type_name = get_type_string_from_graphene_type(argument_nodes)
+    return_type = get_python_type_from_graphene_type(ctx, argument_nodes)
 
     argument_list: List['ArgumentNode'] = []
     names_to_nodes = zip(argument_node_names[1:], argument_nodes[1:])
@@ -188,15 +202,20 @@ def create_attribute_type(attribute_node: AssignmentStmt) -> Optional['TypeNodeI
     for argument_name, argument_node in names_to_nodes:
         if argument_name in ['description', 'required', 'default_value', 'deprecation_reason']:
             continue
-        type_name = get_type_string_from_graphene_type([argument_node], argument_node_names)
-        argument_list.append(ArgumentNode(name=argument_name, type_name=type_name, context=argument_node))
+        python_type = get_python_type_from_graphene_type(ctx, [argument_node], argument_node_names)
+        argument_list.append(ArgumentNode(name=argument_name, type=python_type, context=argument_node))
 
     return TypeNodeInfo(
         name=name,
-        return_type_name=return_type_name,
+        return_type=return_type,
         arguments=argument_list,
         context=attribute_node,
     )
+
+def are_types_equal(left: Type, right: Type) -> bool:
+    if isinstance(left, AnyType) or isinstance(right, AnyType):
+        return True
+    return left == right
 
 
 def get_metaclass_attribute_types(class_body: List[Statement],
@@ -234,7 +253,7 @@ def get_metaclass_attribute_types(class_body: List[Statement],
             return None
         interface_class_body = tuple_item_node.defn.defs.body  # TODO: Maybe make this safer
         interface_attributes.extend([
-            create_attribute_type(interface_attribute)
+            create_attribute_type(ctx, interface_attribute)
             for interface_attribute in interface_class_body
             if isinstance(interface_attribute, AssignmentStmt)
         ])
@@ -242,11 +261,23 @@ def get_metaclass_attribute_types(class_body: List[Statement],
     return interface_attributes
 
 
+def get_type_mismatch_error_message(arg_name: str, *, graphene_type: Type, resolver_type: Type) -> str:
+    return f'Parameter "{arg_name}" has type {resolver_type}, expected type {graphene_type}'
+
+
 class GraphenePlugin(Plugin):
     @staticmethod
     def get_base_class_hook(fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
         def resolver_and_attribute_type_check(ctx: ClassDefContext) -> None:
             class_body = ctx.cls.defs.body
+            class_bases = ctx.cls.info.bases
+            objecttype_base = next(
+                (base for base in class_bases if base.type.fullname == GRAPHENE_OBJECTTYPE_NAME),
+                None,
+            )
+
+            if not objecttype_base:
+                return
 
             interface_attributes = get_metaclass_attribute_types(class_body, ctx)
             if interface_attributes is None:
@@ -255,8 +286,9 @@ class GraphenePlugin(Plugin):
 
             # TODO: Improve performance by only getting type info for attributes that have
             # names matching resolvers.
+            runtime_type = objecttype_base.args[0]
             attributes_or_none = [
-                create_attribute_type(attribute_node)
+                create_attribute_type(ctx, attribute_node)
                 for attribute_node in class_body
                 if isinstance(attribute_node, AssignmentStmt)
             ] + interface_attributes
@@ -265,7 +297,7 @@ class GraphenePlugin(Plugin):
             ]
 
             resolvers = [ # TODO: Maybe use dicts to increase comparison speed
-                create_resolver_type(resolver_node)
+                create_resolver_type(ctx, resolver_node)
                 for resolver_node in class_body
                 # The check for Decorator assumes we're using `staticmethod`s.
                 if isinstance(resolver_node, (Decorator, FuncDef)) and resolver_node.name.startswith(RESOLVER_PREFIX)
@@ -278,32 +310,57 @@ class GraphenePlugin(Plugin):
                     ctx.api.fail(f'No field with name "{resolver.name}" defined', resolver.context)
                     continue
 
+                previous_object_argument = resolver.arguments[0]
+                if not are_types_equal(previous_object_argument.type, runtime_type):
+                    ctx.api.fail(
+                            get_type_mismatch_error_message(
+                                previous_object_argument.name,
+                                graphene_type=runtime_type,
+                                resolver_type=previous_object_argument.type,
+                            ),
+                        previous_object_argument.context
+                    )
+                    continue
+
                 # Assume there's only one match, but if there is more than one, compare against the last one defined.
                 matching_attribute = matching_attributes[-1]
                 for arg in matching_attribute.arguments:
                     matching_resolver_arguments = [argument for argument in resolver.arguments if argument == arg]
                     if not matching_resolver_arguments:
                         ctx.api.fail(
-                            f'Parameter "{arg.name}" of type {arg.type_name} is missing,'
+                            f'Parameter "{arg.name}" of type {arg.type} is missing,'
                             ' but required in resolver definition', resolver.context
                         )
                         continue
 
                     matching_resolver_argument = matching_resolver_arguments[0]
-                    if matching_resolver_argument.type_name != arg.type_name and 'Any' not in [
-                        matching_resolver_argument.type_name, arg.type_name
-                    ]:
+                    if not are_types_equal(matching_resolver_argument.type, arg.type):
                         ctx.api.fail(
-                            f'Parameter "{matching_resolver_argument.name}" has type '
-                            f'{matching_resolver_argument.type_name}, expected type {arg.type_name}',
-                            matching_resolver_argument.context
+                            get_type_mismatch_error_message(
+                                matching_resolver_argument.name,
+                                graphene_type=arg.type,
+                                resolver_type=matching_resolver_argument.type,
+                            ),
+                            matching_resolver_argument.context,
                         )
 
-        if 'graphene.types.objecttype.ObjectType' in fullname:  # TODO: Use ==
+        if GRAPHENE_OBJECTTYPE_NAME in fullname:  # TODO: Use ==
             return resolver_and_attribute_type_check
 
         return None
 
 
-def plugin(_: str) -> Type[GraphenePlugin]:
+def plugin(_: str) -> TypeOf[GraphenePlugin]:
     return GraphenePlugin
+
+def patch_object_type() -> None:
+    """
+    Patches `graphene.ObjectType` to make it indexable at runttime. This is necessary for it be
+    generic at typechecking time.
+    """
+    ObjectTypeMetaclass = type(ObjectType)
+
+    def __getitem__(cls: TypeOf[TypeOf[ObjectType]], _: Any) -> TypeOf[TypeOf[ObjectType]]:
+        return cls
+
+    ObjectTypeMetaclass.__getitem__ = __getitem__  # type: ignore

--- a/test/runtime_test.py
+++ b/test/runtime_test.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+from graphene import ObjectType, Field, String, ResolveInfo, Schema
+from graphene_plugin import patch_object_type
+
+patch_object_type()
+
+
+class RuntimeTest(TestCase):
+    def test_object_type_is_indexable_at_runtime(self) -> None:
+        class Query(ObjectType[None]):  # pylint: disable=unsubscriptable-object
+            string = Field(String)
+
+            @staticmethod
+            def resolve_string(_: None, __: ResolveInfo) -> str:
+                return 'foo'
+
+        Schema(query=Query)

--- a/test/test-data/unit/graphene_plugin.test
+++ b/test/test-data/unit/graphene_plugin.test
@@ -10,7 +10,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:8: error: Parameter "new_arg" of type Optional[str] is missing, but required in resolver definition
+main:8: error: Parameter "new_arg" of type Union[builtins.str, None] is missing, but required in resolver definition
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -40,7 +40,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:8: error: Parameter "new_arg" has type Optional[int], expected type Optional[str]
+main:8: error: Parameter "new_arg" has type Union[builtins.int, None], expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -56,7 +56,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:8: error: Parameter "new_arg" has type Optional[str], expected type str
+main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type builtins.str
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -72,7 +72,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:8: error: Parameter "new_arg" has type Optional[str], expected type str
+main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type builtins.str
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -88,7 +88,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:8: error: Parameter "new_arg" has type str, expected type Optional[str]
+main:8: error: Parameter "new_arg" has type builtins.str, expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -104,7 +104,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:8: error: Parameter "new_arg" has type Optional[str], expected type str
+main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type builtins.str
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -120,7 +120,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:8: error: Parameter "new_arg" has type str, expected type Optional[str]
+main:8: error: Parameter "new_arg" has type builtins.str, expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -162,7 +162,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:11: error: Parameter "new_arg" has type Optional[MyEnum], expected type Optional[str]
+main:11: error: Parameter "new_arg" has type Union[main.MyEnum, None], expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -218,7 +218,7 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:8: error: Parameter "new_arg" has type Optional[str], expected type Optional[List[Optional[str]]]
+main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type Union[builtins.list[Union[builtins.str, None]], None]
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -248,7 +248,7 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
 [out]
-main:8: error: Parameter "new_arg" has type Optional[str], expected type Optional[dict]
+main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type Union[builtins.dict[Any, Any], None]
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -318,7 +318,7 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[int]) -> Optional[str]:
         return 'hi'
 [out]
-main:13: error: Parameter "new_arg" has type Optional[int], expected type Optional[str]
+main:13: error: Parameter "new_arg" has type Union[builtins.int, None], expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -389,7 +389,7 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, arg: str) -> Optional[str]:
         return 'hi'
 [out]
-main:21: error: Parameter "arg" has type str, expected type Optional[str]
+main:21: error: Parameter "arg" has type builtins.str, expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
 
 
@@ -507,6 +507,110 @@ class TestQuery(ObjectType):
         return 'hi'
 
 [out]
-main:7: error: Parameter "new_arg" has type str, expected type Optional[str]
+main:7: error: Parameter "new_arg" has type builtins.str, expected type Union[builtins.str, None]
 main:7: error: Self argument missing for a non-static method (or an invalid type for self)
 Found 2 errors in 1 file (checked 1 source file)
+
+
+[case test_resolver_with_inaccurate_previous_argument_passes]
+from graphene import ObjectType, Field, ResolveInfo, String
+
+
+class RuntimePerson:
+    name: str
+
+
+class Person(ObjectType[RuntimePerson]):
+    name = Field(String, required=True)
+
+    @staticmethod
+    def resolve_name(person: RuntimePerson, _: ResolveInfo) -> str:
+        return ''
+
+[out]
+Success: no issues found in 1 source file
+
+
+[case test_resolver_with_inaccurate_previous_argument_throws]
+from graphene import ObjectType, Field, ResolveInfo, String
+
+
+class RuntimePerson:
+    name: str
+
+
+class NotAPerson:
+    num_of_tails: int
+
+
+class Person(ObjectType[RuntimePerson]):
+    name = Field(String, required=True)
+
+    @staticmethod
+    def resolve_name(person: NotAPerson, _: ResolveInfo) -> str:
+        return ''
+
+[out]
+main:16: error: Parameter "person" has type main.NotAPerson, expected type main.RuntimePerson
+Found 1 error in 1 file (checked 1 source file)
+
+
+[case test_resolver_with_inaccurate_union_previous_argument_throws]
+from typing import Union
+
+from graphene import ObjectType, Field, ResolveInfo, String
+
+
+class A:
+    name: str
+
+class B:
+    name: str
+
+class C:
+    name: str
+
+
+RT = Union[A, C]
+
+
+class Person(ObjectType[RT]):
+    name = Field(String, required=True)
+
+    @staticmethod
+    def resolve_name(person: Union[A, B], _: ResolveInfo) -> str:
+        return ''
+
+[out]
+main:23: error: Parameter "person" has type Union[main.A, main.B], expected type Union[main.A, main.C]
+Found 1 error in 1 file (checked 1 source file)
+
+
+[case test_resolver_with_same_union_previous_argument_passes]
+from typing import Union
+
+from graphene import ObjectType, Field, ResolveInfo, String
+
+
+class A:
+    name: str
+
+class B:
+    name: str
+
+class C:
+    name: str
+
+
+RT = Union[A, C]
+
+
+class Person(ObjectType[RT]):
+    name = Field(String, required=True)
+
+    @staticmethod
+    def resolve_name(person: RT, _: ResolveInfo) -> str:
+        return ''
+
+[out]
+Success: no issues found in 1 source file


### PR DESCRIPTION
With this change, `ObjectType` is now generic on the type that it will serialize at runtime. The `graphene_plugin` then enforces that the first argument to the `ObjectType`'s resolvers is the same type as the one passed to `ObjectType[]`:

```python
class Person(ObjectType[RuntimePerson]):
    first_name = Field(String, required=True)
    last_name = Field(String, required=True)

    def resolve_first_name(person: RuntimePerson, _: ResolveInfo) -> str:  # passes
        return ''

    def resolve_last_name(person: NotARuntimePerson, _: ResolveInfo) -> str:  # fails
        return ''
```

Also, I have refactored the implementation of the plugin to not rely on strings for checking that types are equal.