### PR TITLE
Add support for type-checking a resolver's return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ For classes with the base class `ObjectType`:
 - Erroring when arguments are included in a field attribute definition, but are missing in the resolver method's signature.
 - Erroring when resolvers are defined that don't have corresponding field attributes.
 - Erroring when the types defined in field attribute `Argument`s don't match up with type annotations in resolvers *perfectly*.
+- Erroring when a resolver's return type does not match the corresponding field attribute definition
 - Some amount of robustness for all of the above features, including type checking custom scalar types out of the box, following `Interface`s defined in a `Meta` class on the `ObjectType` to see additional fields, typing `graphene.Enum` types correctly as strings, supporting both static and non-static resolver methods.
 
 
 Currently not supported:
-- Checking return types of resolvers. This will require some careful definition and potentially the addition of a type generator.
 - Anything to do with `Mutation` classes.
 - Anything to do with parsing graphql query strings passed to `execute_query`.
 

--- a/test/test-data/unit/graphene_plugin.test
+++ b/test/test-data/unit/graphene_plugin.test
@@ -140,7 +140,7 @@ class TestQuery(ObjectType):
     )
 
     @staticmethod
-    def resolve_field(_: None, __: ResolveInfo, new_arg: str) -> Optional[str]:
+    def resolve_field(_: None, __: ResolveInfo, new_arg: str) -> str:
         return 'hi'
 
 [out]
@@ -614,3 +614,139 @@ class Person(ObjectType[RT]):
 
 [out]
 Success: no issues found in 1 source file
+
+
+[case test_resolver_with_wrong_return_type_fails]
+from graphene import ObjectType, Field, ResolveInfo, String
+
+class Person(ObjectType):
+    name = Field(String, required=True)
+
+    @staticmethod
+    def resolve_name(_: None, __: ResolveInfo) -> int:
+        return 0
+
+[out]
+main:7: error: Resolver returns type builtins.int, expected type builtins.str
+Found 1 error in 1 file (checked 1 source file)
+
+
+[case test_resolver_with_wrong_object_return_type_fails]
+from typing import List as ListType
+
+from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull
+
+
+class AnimalModel:
+    species: str
+
+
+class PersonModel:
+    pets: ListType[AnimalModel]
+
+
+class EnemyModel:
+    how_they_have_wronged_me: str
+
+
+class Animal(ObjectType[AnimalModel]):
+    species = Field(String, required=True)
+
+
+class Person(ObjectType[PersonModel]):
+    pets = Field(List(NonNull(Animal)), required=True)
+
+    @staticmethod
+    def resolve_pets(person: PersonModel, _: ResolveInfo) -> ListType[EnemyModel]:
+        return []
+
+[out]
+main:26: error: Resolver returns type builtins.list[main.EnemyModel], expected type typing.Sequence[main.AnimalModel]
+Found 1 error in 1 file (checked 1 source file)
+
+
+[case test_resolver_with_correct_object_return_type_passes]
+from typing import List as ListType
+
+from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull
+
+
+class AnimalModel:
+    species: str
+
+
+class PersonModel:
+    pets: ListType[AnimalModel]
+
+
+class Animal(ObjectType[AnimalModel]):
+    species = Field(String, required=True)
+
+
+class Person(ObjectType[PersonModel]):
+    pets = Field(List(NonNull(Animal)), required=True)
+
+    @staticmethod
+    def resolve_pets(person: PersonModel, _: ResolveInfo) -> ListType[AnimalModel]:
+        return []
+
+[out]
+Success: no issues found in 1 source file
+
+
+[case test_resolver_with_correct_object_union_return_type_passes]
+from typing import List as ListType, Union
+
+from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull
+
+
+class AnimalModel:
+    species: str
+
+
+class ForeignAnimalModel:
+    species: str
+
+
+class PersonModel:
+    pets: ListType[AnimalModel]
+
+
+RuntimeAnimal = Union[AnimalModel, ForeignAnimalModel]
+
+
+class Animal(ObjectType[RuntimeAnimal]):
+    species = Field(String, required=True)
+
+
+class Person(ObjectType[PersonModel]):
+    pets = Field(List(NonNull(Animal)), required=True)
+
+    @staticmethod
+    def resolve_pets(person: PersonModel, _: ResolveInfo) -> ListType[AnimalModel]:
+        return []
+
+[out]
+Success: no issues found in 1 source file
+
+
+[case test_resolver_with_mismatched_return_nullability_fails]
+from typing import List as ListType, Optional
+
+from graphene import ObjectType, Field, ResolveInfo, String
+
+
+class PersonModel:
+    name: Optional[str]
+
+
+class Person(ObjectType[PersonModel]):
+    name = Field(String, required=True)
+
+    @staticmethod
+    def resolve_name(person: PersonModel, _: ResolveInfo) -> Optional[str]:
+        return ''
+
+[out]
+main:14: error: Resolver returns type Union[builtins.str, None], expected type builtins.str
+Found 1 error in 1 file (checked 1 source file)


### PR DESCRIPTION
Now that `ObjectType` is generic on the type that will be serialized at runtime, we can now check that a resolver's return value is correct for both primitives and `ObjectType`s.

With this implementation, the resolver's return value is checked _covariantly_. This is best demonstrated with an example:

```python
class HumanModel:
    name: str

class PersonModel:
    name: str


# The `Person` `ObjectType` serializes either a `PersonModel` or `HumanModel`
class Person(ObjectType[Union[PersonModel, HumanModel]]):
    name = Field(String, required=True)


class Query(ObjectType[None]):
    person = Field(Person, required=True)

    @staticmethod
    def resolve_person(_: None, __: ResolveInfo) -> PersonModel:
        # This resolver having a `PersonModel` return value passes because
        # the type-checking is covariant, and `PersonModel` is a subtype of
        # `Union[PersonModel, HumanModel]`. Other acceptable return types
        # would be `HumanModel` or `Union[PersonModel, HumanModel]`.
        # However a return type of something like
        # `Union[PersonModel, HumanModel, AnimalModel]` would **not** pass.
        return PersonModel()
```