### PR TITLE
Do type-checking at type-checking time

### DIFF
--- a/graphene_plugin.py
+++ b/graphene_plugin.py
@@ -1,381 +1,690 @@
 # pylint: disable=no-name-in-module
 from dataclasses import dataclass
-from typing import Optional, Callable, Type as TypeOf, List, Union, Any, cast
+from itertools import chain
+import re
+from typing import Optional, Callable, Type as TypeOf, List, Any, Dict
 
-from mypy.nodes import AssignmentStmt, Decorator, CallExpr, Argument, TypeInfo, FuncDef, EllipsisExpr, StrExpr, \
-    Statement, ClassDef, SymbolNode, TupleExpr
-from mypy.plugin import Plugin, ClassDefContext
+from mypy.nodes import AssignmentStmt, Decorator, CallExpr, Argument, TypeInfo, FuncDef, Statement, ClassDef, \
+    TupleExpr, NameExpr, Expression, MypyFile, ExpressionStmt, MemberExpr, Var, SymbolTableNode, MDEF, CastExpr
+from mypy.options import Options
+from mypy.plugin import Plugin, AttributeContext, ClassDefContext, SemanticAnalyzerPluginInterface
 from mypy.state import strict_optional_set
 from mypy.subtypes import is_subtype, is_equivalent
-from mypy.types import AnyType, CallableType, UnboundType, Instance, TypeOfAny, Type, NoneType, UnionType
+from mypy.types import AnyType, CallableType, Instance, TypeOfAny, Type, NoneType, UnionType, UnboundType
 
 RESOLVER_PREFIX = 'resolve_'
+
 GRAPHENE_ARGUMENT_NAME = 'graphene.types.argument.Argument'
 GRAPHENE_ENUM_META_NAME = 'graphene.types.enum.EnumMeta'
 GRAPHENE_ENUM_NAME = 'graphene.types.enum.Enum'
 GRAPHENE_LIST_NAME = 'graphene.types.structures.List'
 GRAPHENE_NONNULL_NAME = 'graphene.types.structures.NonNull'
 GRAPHENE_OBJECTTYPE_NAME = 'graphene.types.objecttype.ObjectType'
+GRAPHENE_SCHEMA_NAME = 'graphene.types.schema.Schema'
+GRAPHENE_FIELD_NAME = 'graphene.types.field.Field'
+GRAPHENE_SCALAR_NAME = 'graphene.types.scalars.Scalar'
+GRAPHENE_UNMOUNTED_TYPE_NAME = 'graphene.types.unmountedtype.UnmountedType'
+GRAPHENE_STRUCTURE_NAME = 'graphene.types.structures.Structure'
+
+NOOP_ATTR_NAME = '__graphene_plugin_noop__'
+
+
+def _type_is_a(type_info: TypeInfo, other_fullname: str) -> bool:
+    """
+    Checks if the given type (`type_info`) is some other type (`other_fullname`) or if the other type
+    exists somewhere in its ancestry.
+    """
+    if type_info.fullname == other_fullname:
+        return True
+
+    return any(_type_is_a(base_type_info.type, other_fullname) for base_type_info in type_info.bases)
+
+
+def _add_var_to_class(name: str, typ: Type, info: TypeInfo) -> None:
+    """
+    Add a variable with given name and type to the symbol table of a class.
+    This also takes care about setting necessary attributes on the variable node.
+    """
+
+    var = Var(name)
+    var.info = info
+    var._fullname = f'{info.fullname}.{name}'  # pylint: disable=protected-access
+    var.type = typ
+    info.names[name] = SymbolTableNode(MDEF, var)
+
+
+def _add_attr_access_to_module(module: MypyFile, class_info: TypeInfo, attr_name: str) -> None:
+    """
+    Adds a statement that accesses a given `attr_name` of a type (specified via `class_info`) as the last
+    statement in a `module`.
+    """
+
+    module.defs.append(
+        ExpressionStmt(
+            MemberExpr(
+                CastExpr(NameExpr('None'), Instance(class_info, [])),
+                attr_name,
+            )
+        )
+    )
+
+
+def _get_type_mismatch_error_message(arg_name: str, *, graphene_type: Type, resolver_type: Type) -> str:
+    return f'Parameter "{arg_name}" has type {resolver_type}, expected type {graphene_type}'
+
+
+def _is_field_declaration(statement: Statement) -> bool:
+    """
+    Given some `ClassDef` statement, figure out if it is a `Field()` declaration
+    """
+
+    if not isinstance(statement, AssignmentStmt):
+        return False
+
+    call_expr = statement.rvalue
+    if not isinstance(call_expr, CallExpr):
+        return False
+
+    callee = call_expr.callee
+    if not isinstance(callee, NameExpr):
+        return False
+
+    callee_node = callee.node
+    if not isinstance(callee_node, TypeInfo):
+        return False
+
+    return _type_is_a(callee_node, GRAPHENE_FIELD_NAME)
+
+
+def _get_func_def(expression: Statement) -> Optional[FuncDef]:
+    """
+    Given some `Statement`, return a `FuncDef` if it is a `FuncDef`, the `FuncDef` it wraps if it is a `Decorator`,
+    or `None` if it is neither.
+    """
+
+    if isinstance(expression, FuncDef):
+        return expression
+
+    if isinstance(expression, Decorator):
+        return expression.func
+
+    return None
+
+
+def _get_func_def_ret_type(semanal: SemanticAnalyzerPluginInterface, funcdef: FuncDef) -> Type:
+    """
+    Given a `FuncDef`, return its return-type (or `Any`)
+    """
+
+    ret_type = None
+    type_ = funcdef.type
+
+    if isinstance(type_, CallableType):
+        ret_type = type_.ret_type
+
+    if isinstance(ret_type, UnboundType):
+        ret_type = semanal.anal_type(ret_type)
+
+    return ret_type or AnyType(TypeOfAny.unannotated)
+
+
+def _get_python_type_from_graphene_field_first_argument(
+    semanal: SemanticAnalyzerPluginInterface, argument: Expression, *, covariant: bool, nullable: bool
+) -> Type:
+    """
+    Given the first argument to a `Field()`/`Argument()`, return the corresponding runtime (python) type. E.g.:
+
+    * `String` => `Union[builtins.str, None]`
+    * `NonNull(String)` => `builtins.str`
+    * `NonNull(List(Integer))` => `builtins.list[Union[builtins.int, None]]`
+    """
+
+    type_: Optional[Type] = None
+
+    if isinstance(argument, NameExpr) and isinstance(argument.node, TypeInfo):
+        # This is just the name of something (e.g `String`, `Integer`, `MyObjectType`, etc.)
+        is_scalar = _type_is_a(argument.node, GRAPHENE_SCALAR_NAME)
+        is_objecttype = _type_is_a(argument.node, GRAPHENE_OBJECTTYPE_NAME)
+        is_enum = _type_is_a(argument.node, GRAPHENE_ENUM_NAME)
+
+        if is_scalar:
+            # This is some scalar (either a builtin one like `String` or a user-defined one)
+            parse_value_type = argument.node.names.get('parse_value')
+            ret_type: Optional[Type] = None
+            # Figure out the runtime type of the scalar by looking at the return value of its `parse_value` method
+            if parse_value_type and isinstance(parse_value_type.type, CallableType):
+                ret_type = parse_value_type.type.ret_type
+            elif (
+                parse_value_type
+                and isinstance(parse_value_type.node, Decorator)
+                and isinstance(parse_value_type.node.func.type, CallableType)
+            ):
+                ret_type = parse_value_type.node.func.type.ret_type
+
+            if ret_type:
+                type_ = ret_type
+
+        elif is_objecttype:
+            # This is an `ObjectType` child-class, so get the runtime type by looking at the type arg passed to
+            # `ObjectType[]`
+            type_ = _get_objecttype_subclass_runtime_type(argument.node)
+
+        elif is_enum:
+            # This is an `Enum` child-class, which means its value will just be a `str` at runtime
+            symbol_table_node = semanal.lookup_fully_qualified('builtins.str')
+            assert isinstance(symbol_table_node.node, TypeInfo)
+            type_ = Instance(symbol_table_node.node, [])
+
+    elif isinstance(argument, CallExpr) and isinstance(argument.callee, NameExpr) and argument.args:
+        # This is something being called (e.g. `List()`/`NonNull()`)
+
+        if argument.callee.fullname == GRAPHENE_LIST_NAME:
+            # This is a `List()`
+
+            # Use a `Sequence` if we want type-checking to be covariant
+            iterable_type_name = 'typing.Sequence' if covariant else 'builtins.list'
+
+            # Recursively call to figure out the runtime type of the first arg to `List()` and wrap the result
+            # in a `builtins.list`/`typing.Sequence`.
+            symbol_table_node = semanal.lookup_fully_qualified(iterable_type_name)
+            assert isinstance(symbol_table_node.node, TypeInfo)
+            type_ = Instance(
+                symbol_table_node.node,
+                [_get_python_type_from_graphene_field_first_argument(
+                    semanal, argument.args[0], covariant=covariant, nullable=True
+                )],
+            )
+
+        elif argument.callee.fullname == GRAPHENE_NONNULL_NAME:
+            # This is a `NonNull()`
+
+            # Recursively call to figure out the runtime type of the first arg to `NonNull()` but set the
+            # `nullable` flag to `False` so that the resulting type will **not** be wrapped in a
+            # `Union[X, None]`
+            return _get_python_type_from_graphene_field_first_argument(
+                semanal, argument.args[0], covariant=covariant, nullable=False
+            )
+
+    if isinstance(type_, UnboundType):
+        type_ = semanal.anal_type(type_)
+
+    if not type_:
+        return AnyType(TypeOfAny.unannotated)
+
+    if nullable:
+        return UnionType((type_, NoneType()))
+
+    return type_
+
+
+def _get_argument_value_expression(call: CallExpr, arg_name: str) -> Optional[Expression]:
+    """
+    Given some call, return the expression of one of its arguments' values, or `None` if no
+    argument with that name exists in the call. E.g.:
+
+    `foo(hello='world', iam='joe dart')`, `'iam'` => `'joe dart'`
+    """
+    arg_index = call.arg_names.index(arg_name) if arg_name in call.arg_names else None
+    if arg_index is not None:
+        return call.args[arg_index]
+
+    return None
+
+
+def _is_default_value_kwarg_not_none(expression: CallExpr) -> bool:
+    """
+    Given an `Argument()` expression, return a bool indicating if a `default_value` kwarg was passed, and if
+    it was passed some non-`None` literal. E.g.:
+
+    * `Argument(String)` => `False`
+    * `Argument(String, default_value=None)` => `False`
+    * `Argument(String, default_value='foo')` => `True`
+    """
+
+    default_value_expression = _get_argument_value_expression(expression, 'default_value')
+    if not default_value_expression:
+        return False
+
+    if isinstance(default_value_expression, NameExpr) and default_value_expression.fullname == 'builtins.None':
+        return False
+
+    return True
+
+
+def _is_required_kwarg_true(expression: CallExpr) -> bool:
+    """
+    Given a `Field()`/`Argument()` expression, return a bool indicating if a `required` kwarg was passed, and if
+    it was passed the literal `True`. E.g.:
+
+    * `Field(String)` => `False`
+    * `Field(String, required=False)` => `False`
+    * `Field(String, required=True)` => `True`
+    * `Field(String, required=some_computation())` => `False`
+    """
+
+    required_expression = _get_argument_value_expression(expression, 'required')
+    return isinstance(required_expression, NameExpr) and required_expression.fullname == 'builtins.True'
+
+def _get_python_type_from_graphene_field_instantiation(
+    semanal: SemanticAnalyzerPluginInterface, expression: Expression, *, covariant: bool
+) -> Type:
+    """
+    Given an `Field()` defintion, return the python type that the resolver should return at runtime.
+
+    E.g. `Field(List(NonNull(String)), required=True) -> builtins.list[builtins.str]`
+    """
+
+    if not isinstance(expression, CallExpr):
+        return AnyType(TypeOfAny.unannotated)
+
+    if not isinstance(expression.callee, NameExpr) or expression.callee.fullname != GRAPHENE_FIELD_NAME:
+        return AnyType(TypeOfAny.unannotated)
+
+    if not expression.args:
+        return AnyType(TypeOfAny.unannotated)
+
+    return _get_python_type_from_graphene_field_first_argument(
+        semanal, expression.args[0], covariant=covariant, nullable=not _is_required_kwarg_true(expression)
+    )
+
+
+def _get_python_type_from_graphene_argument_instantiation(
+    semanal: SemanticAnalyzerPluginInterface, expression: CallExpr
+) -> Type:
+    """
+    Given an `Argument()` defintion, return the python type that will be passed to the resolver at runtime.
+
+    E.g. `Argument(List(NonNull(String)), required=True) -> builtins.list[builtins.str]`
+    """
+
+    assert isinstance(expression.callee, NameExpr) and isinstance(expression.callee.node, TypeInfo)
+
+    graphene_type: Optional[Expression] = None
+    if _type_is_a(expression.callee.node, GRAPHENE_UNMOUNTED_TYPE_NAME):
+        # What we actually have here is some graphene type being instantiated directly
+        # (e.g. `foo = String(required=True)` instead of `foo = Argument(String, required=True)`)
+        # In this case, the type of the arg is actually the thing being instantiated, not the first arg
+        if _type_is_a(expression.callee.node, GRAPHENE_STRUCTURE_NAME):
+            # This is a Graphene `Structure` (`List()`/`NonNull()`). Graphene `Structure`s wrap another
+            # type, so we actually want to treat the entire `CallExpr` as the thing to look at
+            # (e.g. `List(String)`) and not just the callee (e.g. `List`).
+            graphene_type = expression
+        else:
+            # This is just a regular `UnmountedType`
+            graphene_type = expression.callee
+    elif expression.args:
+        # We have an `Argument()` instantation. Get the type from the first argument
+        graphene_type = expression.args[0]
+
+    if not graphene_type:
+        return AnyType(TypeOfAny.unannotated)
+
+    is_required = _is_required_kwarg_true(expression)
+    has_non_null_default_value = _is_default_value_kwarg_not_none(expression)
+
+    return _get_python_type_from_graphene_field_first_argument(
+        semanal, graphene_type, covariant=False, nullable=not is_required and not has_non_null_default_value
+    )
+
+
+def _get_objecttype_subclass_runtime_type(type_info: TypeInfo) -> Type:
+    """
+    Get the type that an `ObjectType` child class should serialize at runtime (via the type argument passed to
+    `ObjectType`) (e.g. `ObjectType[Foo] -> Foo`)
+    """
+
+    objecttype_base = next(base for base in type_info.bases if base.type.fullname == GRAPHENE_OBJECTTYPE_NAME)
+    return objecttype_base.args[0]
 
 
 @dataclass
-class ArgumentNode:
+class FieldArgumentInfo:
+    """
+    Contains information about one of a field declarations' arguments, including:
+
+    * name: the name of the argument
+    * type: the type that will be passed to the field's resolver at runtime for this argument
+    """
+
+    name: str
+    type: Type
+
+    @classmethod
+    def for_expression(
+        cls, semanal: SemanticAnalyzerPluginInterface, name: str, expression: CallExpr
+    ) -> 'FieldArgumentInfo':
+        type_ = _get_python_type_from_graphene_argument_instantiation(semanal, expression)
+        return cls(
+            name=name,
+            type=type_,
+        )
+
+
+@dataclass
+class FieldInfo:
+    """
+    Contains information about a field declaration on a graphene `ObjectType` child class, including:
+
+    * name: the name of the field
+    * type: the type the field's resolver must return at runtime
+    * arguments: a Dict of argument name to `FieldArgumentInfo` for each of the field's arguments
+    * context: the field's defintion's AST
+    """
+
+    name: str
+    type: Type
+    arguments: Dict[str, FieldArgumentInfo]
+    context: AssignmentStmt
+
+    @staticmethod
+    def _arguments_for_expression(
+        semanal: SemanticAnalyzerPluginInterface, expression: Expression
+    ) -> List[FieldArgumentInfo]:
+        arguments: List[FieldArgumentInfo] = []
+
+        if (
+            not isinstance(expression, CallExpr)
+            or not isinstance(expression.callee, NameExpr)
+            or not expression.callee.fullname == GRAPHENE_FIELD_NAME
+        ):
+            return []
+
+        for arg_name, arg in list(zip(expression.arg_names, expression.args))[1:]:
+            if (
+                arg_name
+                and isinstance(arg, CallExpr)
+                and isinstance(arg.callee, NameExpr)
+                and isinstance(arg.callee.node, TypeInfo)
+            ):
+                if (
+                    arg.callee.fullname == GRAPHENE_ARGUMENT_NAME
+                    or _type_is_a(arg.callee.node, GRAPHENE_UNMOUNTED_TYPE_NAME)
+                ):
+                    arguments.append(FieldArgumentInfo.for_expression(semanal, arg_name, arg))
+
+        return arguments
+
+    @classmethod
+    def for_statement(cls, semanal: SemanticAnalyzerPluginInterface, statement: AssignmentStmt) -> 'FieldInfo':
+        name_expr = statement.lvalues[0]
+        arguments = cls._arguments_for_expression(semanal, statement.rvalue)
+
+        assert isinstance(name_expr, NameExpr)
+        return cls(
+            name=name_expr.name,
+            type=_get_python_type_from_graphene_field_instantiation(semanal, statement.rvalue, covariant=True),
+            arguments={argument.name: argument for argument in arguments},
+            context=statement,
+        )
+
+
+@dataclass
+class ResolverArgumentInfo:
+    """
+    Contains information about one of a resolver method's keyword arguments, including:
+
+    * name: the name of the field the resolver resolves
+    * type: the type of the argument (via a type annotation)
+    * context: the argument's defintion's AST
+    """
+
     name: str
     type: Type
     context: Argument
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ArgumentNode):
-            return False
-        return self.name == other.name
-
-    def __ne__(self, other: object) -> bool:
-        return not (self == other)
+    @classmethod
+    def for_argument(cls, semanal: SemanticAnalyzerPluginInterface, argument: Argument) -> 'ResolverArgumentInfo':
+        type_annotation = semanal.anal_type(argument.type_annotation) if argument.type_annotation else None
+        return cls(
+            name=argument.variable.name,
+            type=type_annotation or AnyType(TypeOfAny.unannotated),
+            context=argument,
+        )
 
 
 @dataclass
-class TypeNodeInfo:
-    name: str
+class ResolverInfo:
+    """
+    Contains information about the defintion of a resolver method on a Graphene `ObjectType` child class, including:
+
+    * field_name: The name of the field the resolver resolves
+    * return_type: The return type of the resolver method
+    * previous_argument: Information about the "previous" argument of a resolver (a.k.a the first positional argument
+      of a resolver)
+    * arguments: Dict of argument name to `ResolverArgumentInfo` for each of the resolver's keyword arguments
+    * context: The resolver's defintion's AST
+    """
+
+    field_name: str
     return_type: Type
-    arguments: List[ArgumentNode]
-    context: Union[FuncDef, AssignmentStmt, Optional[SymbolNode]]
+    previous_argument: ResolverArgumentInfo
+    arguments: Dict[str, ResolverArgumentInfo]
+    context: FuncDef
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, TypeNodeInfo):
-            return False
-        return self.name == other.name
+    @classmethod
+    def for_funcdef(cls, semanal: SemanticAnalyzerPluginInterface, funcdef: FuncDef) -> 'ResolverInfo':
+        field_name = re.sub(r'^resolve_', '', funcdef.name)
+        arguments = (ResolverArgumentInfo.for_argument(semanal, argument) for argument in funcdef.arguments[2:])
 
-    def __ne__(self, other: object) -> bool:
-        return not (self == other)
-
-
-def create_resolver_type(ctx: ClassDefContext, resolver_node: Union[Decorator, FuncDef]) -> 'TypeNodeInfo':
-    name = resolver_node.name[len(RESOLVER_PREFIX):]  # Chop off the beginning of the name for easier matching later
-    if isinstance(resolver_node, FuncDef):
-        func_def = resolver_node
-    if isinstance(resolver_node, Decorator):
-        func_def = resolver_node.func
-    return_type = (
-        ctx.api.anal_type(func_def.type.ret_type)  # type: ignore[attr-defined, union-attr]
-        if func_def.type.ret_type  # type: ignore[attr-defined, union-attr]
-        else None
-    )
-    return_type = return_type or AnyType(TypeOfAny.unannotated)
-    argument_list: List['ArgumentNode'] = []
-    for argument_node in func_def.arguments:
-        argument_type = ctx.api.anal_type(argument_node.type_annotation) if argument_node.type_annotation else None
-        argument_type = argument_type or AnyType(TypeOfAny.unannotated)
-        arg_name = argument_node.variable.name
-        argument_list.append(ArgumentNode(name=arg_name, type=argument_type, context=argument_node))
-    return TypeNodeInfo(name=name, return_type=return_type, arguments=argument_list, context=func_def)
+        return cls(
+            field_name=field_name,
+            arguments={argument.name: argument for argument in arguments},
+            return_type=_get_func_def_ret_type(semanal, funcdef),
+            context=funcdef,
+            previous_argument=ResolverArgumentInfo.for_argument(semanal, funcdef.arguments[0]),
+        )
 
 
-def wrap_in_nonnull(python_type: Optional[Type], non_null: bool) -> Optional[Type]:
-    if not python_type or isinstance(python_type, AnyType) or non_null:
-        return python_type
+@dataclass
+class ObjectTypeInfo:
+    """
+    Contains information about the defintion of a Graphene `ObjectType` child class, including:
 
-    return UnionType((python_type, NoneType()))
+    * name: the name of the `ObjectType`
+    * fields: A `dict` of field name to `FieldInfo` for each field defintion in the `ObjectType`
+      (e.g. `some_field = Field(String, required=True, description='this is a thing')`)
+    * resolvers: A `dict` of field name to `ResolverInfo` for each resolver method in the `ObjectType`
+      (e.g. `def resolve_some_field(_: None, __: ResolveInfo) -> str: 'hello'`)
+    * runtime_type: The type that this `ObjectType` serializes at runtime, specified via the passing an
+      argument to `ObjectType` (e.g. `class MyObjectType(ObjectType[MyRuntimeType]): ...`)
+    """
 
+    name: str
+    fields: Dict[str, FieldInfo]
+    resolvers: Dict[str, ResolverInfo]
+    runtime_type: Type
 
-def wrap_in_list(ctx: ClassDefContext, python_type: Optional[Type], *, covariant: bool) -> Optional[Type]:
-    if not python_type or isinstance(python_type, AnyType):
-        return python_type
-
-    if covariant:
-        wrapper_info = ctx.api.lookup_fully_qualified('typing.Sequence')
-    else:
-        wrapper_info = ctx.api.lookup_fully_qualified('builtins.list')
-    assert isinstance(wrapper_info.node, TypeInfo)
-
-    return Instance(wrapper_info.node, [python_type])
-
-
-def find_object_base(type_info: TypeInfo, base_name: str) -> Optional[Instance]:
-    return next(
-        (base for base in type_info.bases if base.type.fullname == base_name),
-        None,
-    )
-
-
-def get_python_type_from_graphene_type( # pylint: disable=too-many-branches,too-many-return-statements
-    ctx: ClassDefContext,
-    graphene_types: List[TypeInfo],
-    arg_names: Optional[List[str]] = None,
-    non_null: bool = False,
-    covariant: bool = False,
-) -> Type:
-    if arg_names is None:
-        arg_names = []
-
-    if not non_null and len(graphene_types) == len(arg_names):
-        # Check extra conditions that could make this attribute non-nullable.
-
-        if 'default_value' in arg_names:
-            # If default_value isn't None, then this type isn't nullable.
-            default_value_arg_value = list(zip(graphene_types, arg_names))[arg_names.index('default_value')][0]
-            if not (
-                hasattr(default_value_arg_value, 'fullname') and default_value_arg_value.fullname == 'builtins.None'
+    @staticmethod
+    def _interface_classdefs_for_meta_classdef(
+        semanal: SemanticAnalyzerPluginInterface, classdef: ClassDef
+    ) -> List[ClassDef]:
+        for statement in classdef.defs.body:
+            if (
+                isinstance(statement, AssignmentStmt)
+                and any(isinstance(lval, NameExpr) and lval.name == 'interfaces' for lval in statement.lvalues)
             ):
-                non_null = True
+                if not isinstance(statement.rvalue, TupleExpr):
+                    semanal.fail('"interfaces" attribute in Meta class must be a tuple type', statement)
+                    return []
 
-        if 'required' in arg_names:
-            # If required is True, then this type isn't nullable.
-            required_arg_value = list(zip(graphene_types, arg_names))[arg_names.index('required')][0]
-            if (hasattr(required_arg_value, 'fullname') and required_arg_value.fullname == 'builtins.True'):
-                non_null = True
+                # Loop through tuple and add defintions of graphene `Interface`s to the final list.
+                interface_defs: List[ClassDef] = []
+                for item in statement.rvalue.items:
+                    if (
+                        isinstance(item, NameExpr)
+                        and isinstance(item.node, TypeInfo)
+                        and isinstance(item.node.defn, ClassDef)
+                    ):
+                        interface_defs.append(item.node.defn)
 
-    graphene_type = graphene_types[0]
-    if isinstance(graphene_type, StrExpr):
-        return AnyType(TypeOfAny.explicit)  # TODO: Look up the name of graphene_type.value with the api?
-    # if isinstance(graphene_type, NameExpr):
-    #     graphene_type = graphene_type.node
+                return interface_defs
 
-    if isinstance(graphene_type, CallExpr):
-        # This appears to be a graphene type instatiation.
-        if not hasattr(graphene_type, 'callee'):
-            # TODO: Figure out the None case (starargs?) AND check this is still happening
-            return AnyType(TypeOfAny.explicit)
-        if graphene_type.callee.fullname == GRAPHENE_ARGUMENT_NAME:
-            return get_python_type_from_graphene_type(
-                ctx, graphene_type.args, graphene_type.arg_names, covariant=covariant
-            )
-        if graphene_type.callee.fullname == GRAPHENE_NONNULL_NAME:
-            return get_python_type_from_graphene_type(ctx, graphene_type.args, non_null=True, covariant=covariant)
-        if graphene_type.callee.fullname == GRAPHENE_LIST_NAME:
-            return wrap_in_nonnull(
-                wrap_in_list(
-                    ctx,
-                    get_python_type_from_graphene_type(ctx, graphene_type.args, covariant=covariant),
-                    covariant=covariant
-                ),
-                non_null,
-            )
-        # This looks like a call to a scalar type, e.g. String().
-        # Setting the type to the callee allows it to be evaluated correctly by the next check.
-        graphene_type = graphene_type.callee
+        return []
 
-    if (
-        hasattr(graphene_type, 'node')  \
-        and hasattr(graphene_type.node, 'names')  # type: ignore[attr-defined]
-        and 'parse_value' in graphene_type.node.names  # type: ignore[attr-defined]
-    ):
-        # This is a scalar type.
-        # Look at the parse_value method on a Scalar class and figure out its
-        # return type, or default to Any.
-        current_type = graphene_type.node['parse_value'].type  # type: ignore[attr-defined]
-        if current_type is None:
-            current_node = graphene_type.node['parse_value'].node  # type: ignore[attr-defined]
-            if isinstance(current_node, Decorator):
-                # This is likely a static method.
-                current_type = current_node.func.type
-                # if isinstance(current_type.ret_type, AnyType):
-                #     return 'Any'
-                # return_type_name = current_type.ret_type.name
-            else:
-                # I don't know what this is, let's just return Any.
-                return AnyType(TypeOfAny.explicit)
+    @classmethod
+    def _interfaces_for_classdef(cls, semanal: SemanticAnalyzerPluginInterface, classdef: ClassDef) -> List[ClassDef]:
+        for statement in classdef.defs.body:
+            if isinstance(statement, ClassDef) and statement.name == 'Meta':
+                return cls._interface_classdefs_for_meta_classdef(semanal, statement)
 
-        return_type: Optional[Type] = None
-        if isinstance(current_type, CallableType):
-            if isinstance(current_type.ret_type, AnyType):
-                return current_type.ret_type
-            if isinstance(current_type.ret_type, Instance):
-                return_type = current_type.ret_type
-            elif isinstance(current_type.ret_type, UnboundType):
-                return_type = ctx.api.anal_type(current_type.ret_type)  # type: ignore[attr-defined]
-        elif current_type.is_type_obj():
-            return_type = Instance(current_type.type_object(), args=[])
+        return []
 
-    elif (
-        getattr(graphene_type, 'node', None) is not None
-        and hasattr(graphene_type.node, 'bases')  # type: ignore[attr-defined]
-    ):
-        graphene_type_node = cast(TypeInfo, graphene_type.node)  # type: ignore[attr-defined]
-        enum_base = find_object_base(graphene_type_node, GRAPHENE_ENUM_NAME)
-        objecttype_base = find_object_base(graphene_type_node, GRAPHENE_OBJECTTYPE_NAME)
+    @classmethod
+    def _resolvers_for_classdef(
+        cls, semanal: SemanticAnalyzerPluginInterface, classdef: ClassDef
+    ) -> List[ResolverInfo]:
+        resolvers: List[ResolverInfo] = []
 
-        if enum_base:
-            return_type = ctx.api.named_type('str')
-        elif objecttype_base:
-            return_type = objecttype_base.args[0]
-        else:
-            return AnyType(TypeOfAny.explicit)
-    else:
-        # TODO: Come up with better fallback behavior.
-        return AnyType(TypeOfAny.explicit)
-    return wrap_in_nonnull(return_type, non_null) or AnyType(TypeOfAny.unannotated)
+        for statement in classdef.defs.body:
+            funcdef = _get_func_def(statement)
+            if funcdef and funcdef.name.startswith(RESOLVER_PREFIX):
+                resolvers.append(ResolverInfo.for_funcdef(semanal, funcdef))
 
+        return resolvers
 
-def create_attribute_type(ctx: ClassDefContext, attribute_node: AssignmentStmt) -> Optional['TypeNodeInfo']:
-    # Collect type info about an  attribute on graphene ObjectType classes,
-    # e.g. `attribute = Field(String, match_cookie=Argument(List(NonNull(Float))))`
-    if isinstance(attribute_node.rvalue, EllipsisExpr):
-        # This is inside a stub, there's nothing to do.
-        return None
-    if not hasattr(attribute_node.rvalue, 'args'):
-        # This is not a Field or Argument instantiation.
-        return None
+    @classmethod
+    def _fields_for_classdef(cls, semanal: SemanticAnalyzerPluginInterface, classdef: ClassDef) -> List[FieldInfo]:
+        fields: List[FieldInfo] = []
 
-    # `<attribute> = Field(String, match_cookie=Argument(List(NonNull(Float))))`
-    name = attribute_node.lvalues[0].name  # type: ignore[attr-defined]
-    # `attribute = Field(<String>, <match_cookie=Argument(List(NonNull(Float)))>)`
-    argument_nodes = attribute_node.rvalue.args  # type: ignore[attr-defined]
-    if not argument_nodes:
-        return None
+        # Include fields defined on an interface
+        interface_def_statements = list(
+            chain(*(interface.defs.body for interface in cls._interfaces_for_classdef(semanal, classdef)))
+        )
+        for statement in (classdef.defs.body + interface_def_statements):
+            if _is_field_declaration(statement):
+                assert isinstance(statement, AssignmentStmt)
+                if isinstance(statement.lvalues[0], NameExpr):
+                    fields.append(FieldInfo.for_statement(semanal, statement))
 
-    argument_node_names = attribute_node.rvalue.arg_names  # type: ignore[attr-defined]
-    return_type = get_python_type_from_graphene_type(ctx, argument_nodes, argument_node_names, covariant=True)
+        return fields
 
-    argument_list: List['ArgumentNode'] = []
-    names_to_nodes = zip(argument_node_names[1:], argument_nodes[1:])
+    @classmethod
+    def for_classdef(cls, semanal: SemanticAnalyzerPluginInterface, classdef: ClassDef) -> 'ObjectTypeInfo':
+        resolvers = {resolver.field_name: resolver for resolver in cls._resolvers_for_classdef(semanal, classdef)}
+        fields = {field.name: field for field in cls._fields_for_classdef(semanal, classdef)}
+        runtime_type = _get_objecttype_subclass_runtime_type(classdef.info)
 
-    for argument_name, argument_node in names_to_nodes:
-        if argument_name in ['description', 'required', 'default_value', 'deprecation_reason']:
-            continue
-        python_type = get_python_type_from_graphene_type(ctx, [argument_node], argument_node_names, covariant=False)
-        argument_list.append(ArgumentNode(name=argument_name, type=python_type, context=argument_node))
-
-    return TypeNodeInfo(
-        name=name,
-        return_type=return_type,
-        arguments=argument_list,
-        context=attribute_node,
-    )
-
-
-def get_metaclass_attribute_types(class_body: List[Statement],
-                                  ctx: ClassDefContext) -> Optional[List[Optional[TypeNodeInfo]]]:
-    # Weakly support interfaces.
-    interface_attributes: List[Optional[TypeNodeInfo]] = []
-
-    meta_classes = [
-        attribute for attribute in class_body if isinstance(attribute, ClassDef) and attribute.name == 'Meta'
-    ]
-    interfaces: List[AssignmentStmt] = []
-    if meta_classes:
-        meta_class_body = meta_classes[0].defs.body
-        interfaces = [
-            attribute for attribute in meta_class_body
-            if isinstance(attribute, AssignmentStmt) \
-            and attribute.lvalues[0].name == 'interfaces' # type: ignore[attr-defined]
-        ]
-
-    if not interfaces:
-        return interface_attributes
-
-    tuple_expr = interfaces[0].rvalue
-    if not isinstance(tuple_expr, TupleExpr):
-        not_a_tuple_error_message = '"interfaces" attribute in Meta class must be a tuple type'
-        if hasattr(tuple_expr, 'line'):  # This unknown node type can be used as context for an error
-            ctx.api.fail(not_a_tuple_error_message, tuple_expr)
-        else:
-            ctx.api.fail(not_a_tuple_error_message, tuple_expr)
-        return interface_attributes
-
-    for tuple_item in tuple_expr.items:
-        tuple_item_node = tuple_item.node  # type: ignore[attr-defined]
-        if not tuple_item_node:
-            return None
-        interface_class_body = tuple_item_node.defn.defs.body  # TODO: Maybe make this safer
-        interface_attributes.extend([
-            create_attribute_type(ctx, interface_attribute)
-            for interface_attribute in interface_class_body
-            if isinstance(interface_attribute, AssignmentStmt)
-        ])
-
-    return interface_attributes
-
-
-def get_type_mismatch_error_message(arg_name: str, *, graphene_type: Type, resolver_type: Type) -> str:
-    return f'Parameter "{arg_name}" has type {resolver_type}, expected type {graphene_type}'
+        return cls(
+            name=classdef.name,
+            fields=fields,
+            resolvers=resolvers,
+            runtime_type=runtime_type,
+        )
 
 
 class GraphenePlugin(Plugin):
-    @staticmethod
-    def get_base_class_hook(fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
-        @strict_optional_set(True)
-        def resolver_and_attribute_type_check(ctx: ClassDefContext) -> None:
-            class_body = ctx.cls.defs.body
-            objecttype_base = find_object_base(ctx.cls.info, GRAPHENE_OBJECTTYPE_NAME)
+    def __init__(self, options: Options) -> None:
+        super().__init__(options)
 
-            if not objecttype_base:
-                return
+        self._objecttypes: Dict[str, ObjectTypeInfo] = {}
 
-            interface_attributes = get_metaclass_attribute_types(class_body, ctx)
-            if interface_attributes is None:
+    def get_base_class_hook(self, fullname: str) -> Optional[Callable[[ClassDefContext], None]]:
+        def collect_objecttype_subclass(ctx: ClassDefContext) -> None:
+            """
+            Collect type information about graphene `ObjectType` child classes. This plugin is invoked
+            during semantic analysis.
+            """
+
+            if not ctx.api.final_iteration:
                 ctx.api.defer()
                 return
 
-            # TODO: Improve performance by only getting type info for attributes that have
-            # names matching resolvers.
-            runtime_type = objecttype_base.args[0]
-            attributes_or_none = [
-                create_attribute_type(ctx, attribute_node)
-                for attribute_node in class_body
-                if isinstance(attribute_node, AssignmentStmt)
-            ] + interface_attributes
-            attributes = [
-                attribute_or_none for attribute_or_none in attributes_or_none if attribute_or_none is not None
-            ]
+            module = ctx.api.modules[ctx.cls.info.module_name]
 
-            resolvers = [ # TODO: Maybe use dicts to increase comparison speed
-                create_resolver_type(ctx, resolver_node)
-                for resolver_node in class_body
-                # The check for Decorator assumes we're using `staticmethod`s.
-                if isinstance(resolver_node, (Decorator, FuncDef)) and resolver_node.name.startswith(RESOLVER_PREFIX)
-            ]
+            self._objecttypes[ctx.cls.info.fullname] = ObjectTypeInfo.for_classdef(ctx.api, ctx.cls)
 
-            for resolver in resolvers:
-                matching_attributes = [attribute for attribute in attributes if attribute == resolver]
-                assert resolver.context is not None
-                if not matching_attributes:
-                    ctx.api.fail(f'No field with name "{resolver.name}" defined', resolver.context)
+            # Here is the fun hack. We want to type-check our `ObjectType`s at type-checking time, but
+            # the `get_base_class_hook` only runs at semantic analysis time and as of now there is no
+            # classdef hook that runs at type-checking time. To work around this, we do two things:
+            #
+            # * First, we add a dummy attribute to the `ObjectType` child class (__graphene_plugin_noop__)
+            # * Then, we add some statements to the module's AST that effectively do this:
+            #   `cast(MyObjectType, None).__graphene_plugin_noop__`
+            #
+            # Because mypy has a `get_attribute_hook` plugin hook that is invoked during type-checking time
+            # we now can rely on that hook to perform our type-checking of the `ObjectType`.
+            _add_var_to_class(NOOP_ATTR_NAME, NoneType(), ctx.cls.info)
+            _add_attr_access_to_module(module, ctx.cls.info, NOOP_ATTR_NAME)
+
+        if fullname == GRAPHENE_OBJECTTYPE_NAME:
+            return collect_objecttype_subclass
+
+        return None
+
+    def get_attribute_hook(self, fullname: str) -> Optional[Callable[[AttributeContext], Type]]:
+        @strict_optional_set(True)
+        def process_gql_schema(ctx: AttributeContext) -> Type:
+            """
+            Actually perform the type-checking logic for each graphene `ObjectType` child class.
+            The plugin is invoked at type-checking time.
+            """
+
+            assert isinstance(ctx.type, Instance)
+            objecttype_info = self._objecttypes[ctx.type.type.fullname]
+
+            for field in objecttype_info.fields.values():
+                resolver = objecttype_info.resolvers.get(field.name)
+
+                if not resolver:
+                    # TODO: check that default resolver will reference the correct type
                     continue
 
-                previous_object_argument = resolver.arguments[0]
-                if not is_equivalent(previous_object_argument.type, runtime_type):
+                # Check that the resolver's "previous" (first) argument has the correct type
+                if not is_equivalent(resolver.previous_argument.type, objecttype_info.runtime_type):
                     ctx.api.fail(
-                            get_type_mismatch_error_message(
-                                previous_object_argument.name,
-                                graphene_type=runtime_type,
-                                resolver_type=previous_object_argument.type,
-                            ),
-                        previous_object_argument.context
+                        _get_type_mismatch_error_message(
+                            resolver.previous_argument.name,
+                            graphene_type=objecttype_info.runtime_type,
+                            resolver_type=resolver.previous_argument.type,
+                        ),
+                        resolver.previous_argument.context,
                     )
                     continue
 
-                # Assume there's only one match, but if there is more than one, compare against the last one defined.
-                matching_attribute = matching_attributes[-1]
-
-                if not is_subtype(resolver.return_type, matching_attribute.return_type):
+                # Check that the resolver returns the correct type
+                if not is_subtype(resolver.return_type, field.type):
                     ctx.api.fail(
-                        f'Resolver returns type {resolver.return_type}, expected type {matching_attribute.return_type}',
+                        f'Resolver returns type {resolver.return_type}, expected type {field.type}',
                         resolver.context,
                     )
                     continue
 
-                for arg in matching_attribute.arguments:
-                    matching_resolver_arguments = [argument for argument in resolver.arguments if argument == arg]
-                    if not matching_resolver_arguments:
+                for field_argument in field.arguments.values():
+                    resolver_argument = resolver.arguments.get(field_argument.name)
+
+                    # Check that the resolver has an argument for each argument the `Field()` defines
+                    if not resolver_argument:
                         ctx.api.fail(
-                            f'Parameter "{arg.name}" of type {arg.type} is missing,'
-                            ' but required in resolver definition', resolver.context
+                            f'Parameter "{field_argument.name}" of type {field_argument.type} is missing,'
+                            ' but required in resolver definition',
+                            resolver.context,
                         )
                         continue
 
-                    matching_resolver_argument = matching_resolver_arguments[0]
-                    if not is_equivalent(matching_resolver_argument.type, arg.type):
+                    # Check that the resolver's argument has the correct type annotation
+                    if not is_equivalent(field_argument.type, resolver_argument.type):
                         ctx.api.fail(
-                            get_type_mismatch_error_message(
-                                matching_resolver_argument.name,
-                                graphene_type=arg.type,
-                                resolver_type=matching_resolver_argument.type,
+                            _get_type_mismatch_error_message(
+                                field_argument.name,
+                                graphene_type=field_argument.type,
+                                resolver_type=resolver_argument.type,
                             ),
-                            matching_resolver_argument.context,
+                            resolver_argument.context,
                         )
+                        continue
 
-        if GRAPHENE_OBJECTTYPE_NAME in fullname:  # TODO: Use ==
-            return resolver_and_attribute_type_check
+            # Check the every resolver function has a corresponding `Field()` defintion
+            missing_field_names = set(objecttype_info.resolvers.keys()) - set(objecttype_info.fields.keys())
+            for name in missing_field_names:
+                resolver = objecttype_info.resolvers[name]
+
+                ctx.api.fail(f'No field with name "{resolver.field_name}" defined', resolver.context)
+                continue
+
+            return ctx.default_attr_type
+
+        if fullname.endswith(NOOP_ATTR_NAME):
+            return process_gql_schema
 
         return None
 

--- a/graphene_plugin.py
+++ b/graphene_plugin.py
@@ -142,7 +142,8 @@ def _get_python_type_from_graphene_field_first_argument(
     type_: Optional[Type] = None
 
     if isinstance(argument, NameExpr) and isinstance(argument.node, TypeInfo):
-        # This is just the name of something (e.g `String`, `Integer`, `MyObjectType`, etc.)
+        # This is just a plain graphene type that doesn't wrap anything (i.e `String`, `MyObjectType`,
+        # **not** `List(String)`, `NonNull(MyObjectType), etc.)``
         is_scalar = _type_is_a(argument.node, GRAPHENE_SCALAR_NAME)
         is_objecttype = _type_is_a(argument.node, GRAPHENE_OBJECTTYPE_NAME)
         is_enum = _type_is_a(argument.node, GRAPHENE_ENUM_NAME)
@@ -269,7 +270,7 @@ def _get_python_type_from_graphene_field_instantiation(
     semanal: SemanticAnalyzerPluginInterface, expression: Expression, *, covariant: bool
 ) -> Type:
     """
-    Given an `Field()` defintion, return the python type that the resolver should return at runtime.
+    Given an `Field()` definition, return the python type that the resolver should return at runtime.
 
     E.g. `Field(List(NonNull(String)), required=True) -> builtins.list[builtins.str]`
     """
@@ -334,6 +335,8 @@ def _get_objecttype_subclass_runtime_type(type_info: TypeInfo) -> Type:
     """
 
     objecttype_base = next(base for base in type_info.bases if base.type.fullname == GRAPHENE_OBJECTTYPE_NAME)
+    # Note: even if no type argument was passed to `ObjectType` when it was sub-classed, there will still be
+    # an item in the `args` list below. It will just be `Any`.
     return objecttype_base.args[0]
 
 

--- a/test/test-data/unit/graphene_plugin.test
+++ b/test/test-data/unit/graphene_plugin.test
@@ -1,6 +1,6 @@
 [case test_argument_missing_from_resolver_throws]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(String))
@@ -8,6 +8,8 @@ class TestQuery(ObjectType):
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo) -> Optional[str]:
         return 'hi'
+
+schema = Schema(query=TestQuery)
 
 [out]
 main:8: error: Parameter "new_arg" of type Union[builtins.str, None] is missing, but required in resolver definition
@@ -16,12 +18,15 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_missing_field_throws]
 from typing import Optional
-from graphene import ObjectType, Argument, ResolveInfo, String
+from graphene import ObjectType, Argument, ResolveInfo, String, Schema
 
 class TestQuery(ObjectType):
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
 
 [out]
 main:6: error: No field with name "field" defined
@@ -30,7 +35,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_type_mismatch_throws]
 from typing import Optional
-from graphene import ObjectType, Argument, ResolveInfo, String, Field
+from graphene import ObjectType, Argument, ResolveInfo, String, Field, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(String))
@@ -39,6 +44,9 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[int]) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 main:8: error: Parameter "new_arg" has type Union[builtins.int, None], expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
@@ -46,7 +54,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_optional_annotation_on_nonnull_variable_throws]
 from typing import Optional
-from graphene import ObjectType, Argument, ResolveInfo, String, Field, NonNull
+from graphene import ObjectType, Argument, ResolveInfo, String, Field, NonNull, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(NonNull(String)))
@@ -55,6 +63,9 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type builtins.str
 Found 1 error in 1 file (checked 1 source file)
@@ -62,7 +73,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_optional_annotation_on_required_variable_throws]
 from typing import Optional
-from graphene import ObjectType, Argument, ResolveInfo, String, Field
+from graphene import ObjectType, Argument, ResolveInfo, String, Field, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(String, required=True))
@@ -71,6 +82,9 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type builtins.str
 Found 1 error in 1 file (checked 1 source file)
@@ -78,7 +92,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_non_optional_annotation_on_variable_with_required_set_to_false_throws]
 from typing import Optional
-from graphene import ObjectType, Argument, ResolveInfo, String, Field
+from graphene import ObjectType, Argument, ResolveInfo, String, Field, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(String, required=False))
@@ -87,30 +101,17 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: str) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 main:8: error: Parameter "new_arg" has type builtins.str, expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
 
 
-[case test_optional_annotation_on_variable_with_non_none_default_value_throws]
-from typing import Optional
-from graphene import ObjectType, Argument, ResolveInfo, String, Field
-
-class TestQuery(ObjectType):
-    field = Field(String, new_arg=Argument(String, default_value='hi'))
-
-    @staticmethod
-    def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
-        return 'hi'
-
-[out]
-main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type builtins.str
-Found 1 error in 1 file (checked 1 source file)
-
-
 [case test_non_optional_annotation_on_variable_with_none_default_value_throws]
 from typing import Optional
-from graphene import ObjectType, Argument, ResolveInfo, String, Field
+from graphene import ObjectType, Argument, ResolveInfo, String, Field, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(String, default_value=None))
@@ -119,6 +120,9 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: str) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 main:8: error: Parameter "new_arg" has type builtins.str, expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
@@ -126,7 +130,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_non_field_argument_attributes_are_ignored]
 from typing import Optional
-from graphene import ObjectType, Argument, ResolveInfo, String, Field
+from graphene import ObjectType, Argument, ResolveInfo, String, Field, Schema
 
 class TestQuery(ObjectType):
     # Test to make sure name, description, required, and default_value arguments aren't
@@ -143,13 +147,16 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: str) -> str:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_enum_with_inaccurate_annotation_throws]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, Enum
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Enum, Schema
 
 class MyEnum(Enum):
     one = 'ONE'
@@ -161,6 +168,9 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[MyEnum]) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 main:11: error: Parameter "new_arg" has type Union[main.MyEnum, None], expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
@@ -169,7 +179,7 @@ Found 1 error in 1 file (checked 1 source file)
 [case test_unsupported_type_with_any_annotation_passes]
 from typing import Optional
 from enum import Enum as PyEnum
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, Enum
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Enum, Schema
 
 class MyEnum(PyEnum):
     one = 'ONE'
@@ -184,13 +194,16 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_enum_with_accurate_annotation_passes]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, Enum
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Enum, Schema
 
 class MyEnum(Enum):
     one = 'ONE'
@@ -202,13 +215,16 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_list_type_with_inaccurate_annotation_throws]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, List
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, List, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(List(String)))
@@ -216,6 +232,9 @@ class TestQuery(ObjectType):
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
 
 [out]
 main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type Union[builtins.list[Union[builtins.str, None]], None]
@@ -224,7 +243,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_list_type_with_accurate_annotation_passes]
 from typing import Optional, List as ListType
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, List
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, List, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(List(String)))
@@ -233,13 +252,16 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[ListType[Optional[str]]]) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_json_type_with_inaccurate_annotation_throws]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, JSONString
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, JSONString, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(JSONString))
@@ -247,6 +269,10 @@ class TestQuery(ObjectType):
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
+
 [out]
 main:8: error: Parameter "new_arg" has type Union[builtins.str, None], expected type Union[builtins.dict[Any, Any], None]
 Found 1 error in 1 file (checked 1 source file)
@@ -254,7 +280,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_json_type_with_accurate_annotation_passes]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, JSONString
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, JSONString, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(JSONString))
@@ -262,13 +288,17 @@ class TestQuery(ObjectType):
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[dict]) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_interface_attribute_with_accurate_annotation_passes]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, Interface
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Interface, Schema
 
 class SimpleInterface(Interface):
     field = Field(String, new_arg=Argument(String))
@@ -277,34 +307,42 @@ class SimpleInterface(Interface):
 class TestQuery(ObjectType):
     class Meta:
         interfaces = (SimpleInterface,)
-    
+
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 [case test_interface_attribute_forward_reference_passes]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, Interface
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Interface, Schema
 
 class TestQuery(ObjectType):
     class Meta:
         interfaces = (SimpleInterfaceAfter,)
-    
+
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
 
 class SimpleInterfaceAfter(Interface):
     field = Field(String, new_arg=Argument(String))
+
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_interface_attribute_with_inaccurate_annotation_throws]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, Interface
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Interface, Schema
 
 class SimpleInterface(Interface):
     field = Field(String, new_arg=Argument(String))
@@ -313,10 +351,14 @@ class SimpleInterface(Interface):
 class TestQuery(ObjectType):
     class Meta:
         interfaces = (SimpleInterface,)
-    
+
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[int]) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
+
 [out]
 main:13: error: Parameter "new_arg" has type Union[builtins.int, None], expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
@@ -324,7 +366,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_non_tuple_interface_attribute_on_meta_class_throws]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String, Interface
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Interface, Schema
 
 class SimpleInterface(Interface):
     field = Field(String, new_arg=Argument(String))
@@ -333,6 +375,10 @@ class SimpleInterface(Interface):
 class TestQuery(ObjectType):
     class Meta:
         interfaces = 'hi'
+
+
+Schema(query=TestQuery)
+
 [out]
 main:10: error: "interfaces" attribute in Meta class must be a tuple type
 Found 1 error in 1 file (checked 1 source file)
@@ -340,7 +386,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_custom_graphene_scalar_with_accurate_resolver_annotation_passes]
 from typing import Optional, Any
-from graphene import ObjectType, Field, Scalar, ResolveInfo, Argument
+from graphene import ObjectType, Field, Scalar, ResolveInfo, Argument, Schema
 
 
 class JSONString(Scalar):
@@ -361,13 +407,17 @@ class TestQuery(ObjectType):
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo, arg: Optional[str]) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_custom_graphene_scalar_with_inaccurate_resolver_annotation_fails]
 from typing import Optional, Any
-from graphene import ObjectType, Field, Scalar, ResolveInfo, Argument
+from graphene import ObjectType, Field, Scalar, ResolveInfo, Argument, Schema
 
 
 class JSONString(Scalar):
@@ -388,6 +438,10 @@ class TestQuery(ObjectType):
     @staticmethod
     def resolve_field(_: None, __: ResolveInfo, arg: str) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
+
 [out]
 main:21: error: Parameter "arg" has type builtins.str, expected type Union[builtins.str, None]
 Found 1 error in 1 file (checked 1 source file)
@@ -395,7 +449,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_custom_graphene_scalar_with_parse_value_returning_any_passes]
 from typing import Optional, Any
-from graphene import ObjectType, Field, Scalar
+from graphene import ObjectType, Field, Scalar, Schema
 
 
 class JSONString(Scalar):
@@ -412,13 +466,17 @@ class JSONString(Scalar):
 
 class TestQuery(ObjectType):
     field = Field(JSONString)
+
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_custom_graphene_scalar_with_parse_value_without_return_type_annotation_passes]
 from typing import Optional, Any
-from graphene import ObjectType, Field, Scalar
+from graphene import ObjectType, Field, Scalar, Schema
 
 
 class JSONString(Scalar):
@@ -435,13 +493,17 @@ class JSONString(Scalar):
 
 class TestQuery(ObjectType):
     field = Field(JSONString)
+
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_custom_graphene_scalar_with_non_static_parse_value_passes]
 from typing import Optional, Any
-from graphene import ObjectType, Field, Scalar
+from graphene import ObjectType, Field, Scalar, Schema
 
 
 class JSONString(Scalar):
@@ -457,12 +519,16 @@ class JSONString(Scalar):
 
 class TestQuery(ObjectType):
     field = Field(JSONString)
+
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 [case test_custom_graphene_scalar_with_non_function_parse_value_passes]
 from typing import Optional, Any
-from graphene import ObjectType, Field, Scalar
+from graphene import ObjectType, Field, Scalar, Schema
 
 
 class JSONString(Scalar):
@@ -477,19 +543,26 @@ class JSONString(Scalar):
 
 class TestQuery(ObjectType):
     field = Field(JSONString)
+
+
+Schema(query=TestQuery)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_non_static_resolver_with_accurate_annotation_passes]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(String))
 
     def resolve_field(_: None, __: ResolveInfo, new_arg: Optional[str]) -> Optional[str]:
         return 'hi'
+
+
+Schema(query=TestQuery)
 
 [out]
 main:7: error: Self argument missing for a non-static method (or an invalid type for self)
@@ -498,7 +571,7 @@ Found 1 error in 1 file (checked 1 source file)
 
 [case test_non_static_resolver_with_inaccurate_annotation_throws]
 from typing import Optional
-from graphene import ObjectType, Field, Argument, ResolveInfo, String
+from graphene import ObjectType, Field, Argument, ResolveInfo, String, Schema
 
 class TestQuery(ObjectType):
     field = Field(String, new_arg=Argument(String))
@@ -506,14 +579,17 @@ class TestQuery(ObjectType):
     def resolve_field(_: None, __: ResolveInfo, new_arg: str) -> Optional[str]:
         return 'hi'
 
+
+Schema(query=TestQuery)
+
 [out]
-main:7: error: Parameter "new_arg" has type builtins.str, expected type Union[builtins.str, None]
 main:7: error: Self argument missing for a non-static method (or an invalid type for self)
+main:7: error: Parameter "new_arg" has type builtins.str, expected type Union[builtins.str, None]
 Found 2 errors in 1 file (checked 1 source file)
 
 
 [case test_resolver_with_inaccurate_previous_argument_passes]
-from graphene import ObjectType, Field, ResolveInfo, String
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
 
 
 class RuntimePerson:
@@ -527,12 +603,15 @@ class Person(ObjectType[RuntimePerson]):
     def resolve_name(person: RuntimePerson, _: ResolveInfo) -> str:
         return ''
 
+
+Schema(query=Person)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_resolver_with_inaccurate_previous_argument_throws]
-from graphene import ObjectType, Field, ResolveInfo, String
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
 
 
 class RuntimePerson:
@@ -550,6 +629,9 @@ class Person(ObjectType[RuntimePerson]):
     def resolve_name(person: NotAPerson, _: ResolveInfo) -> str:
         return ''
 
+
+Schema(query=Person)
+
 [out]
 main:16: error: Parameter "person" has type main.NotAPerson, expected type main.RuntimePerson
 Found 1 error in 1 file (checked 1 source file)
@@ -558,7 +640,7 @@ Found 1 error in 1 file (checked 1 source file)
 [case test_resolver_with_inaccurate_union_previous_argument_throws]
 from typing import Union
 
-from graphene import ObjectType, Field, ResolveInfo, String
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
 
 
 class A:
@@ -581,6 +663,9 @@ class Person(ObjectType[RT]):
     def resolve_name(person: Union[A, B], _: ResolveInfo) -> str:
         return ''
 
+
+Schema(query=Person)
+
 [out]
 main:23: error: Parameter "person" has type Union[main.A, main.B], expected type Union[main.A, main.C]
 Found 1 error in 1 file (checked 1 source file)
@@ -589,7 +674,7 @@ Found 1 error in 1 file (checked 1 source file)
 [case test_resolver_with_same_union_previous_argument_passes]
 from typing import Union
 
-from graphene import ObjectType, Field, ResolveInfo, String
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
 
 
 class A:
@@ -612,12 +697,15 @@ class Person(ObjectType[RT]):
     def resolve_name(person: RT, _: ResolveInfo) -> str:
         return ''
 
+
+Schema(query=Person)
+
 [out]
 Success: no issues found in 1 source file
 
 
 [case test_resolver_with_wrong_return_type_fails]
-from graphene import ObjectType, Field, ResolveInfo, String
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
 
 class Person(ObjectType):
     name = Field(String, required=True)
@@ -625,6 +713,9 @@ class Person(ObjectType):
     @staticmethod
     def resolve_name(_: None, __: ResolveInfo) -> int:
         return 0
+
+
+Schema(query=Person)
 
 [out]
 main:7: error: Resolver returns type builtins.int, expected type builtins.str
@@ -634,7 +725,7 @@ Found 1 error in 1 file (checked 1 source file)
 [case test_resolver_with_wrong_object_return_type_fails]
 from typing import List as ListType
 
-from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull
+from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull, Schema
 
 
 class AnimalModel:
@@ -660,6 +751,9 @@ class Person(ObjectType[PersonModel]):
     def resolve_pets(person: PersonModel, _: ResolveInfo) -> ListType[EnemyModel]:
         return []
 
+
+Schema(query=Person)
+
 [out]
 main:26: error: Resolver returns type builtins.list[main.EnemyModel], expected type typing.Sequence[main.AnimalModel]
 Found 1 error in 1 file (checked 1 source file)
@@ -668,7 +762,7 @@ Found 1 error in 1 file (checked 1 source file)
 [case test_resolver_with_correct_object_return_type_passes]
 from typing import List as ListType
 
-from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull
+from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull, Schema
 
 
 class AnimalModel:
@@ -690,6 +784,9 @@ class Person(ObjectType[PersonModel]):
     def resolve_pets(person: PersonModel, _: ResolveInfo) -> ListType[AnimalModel]:
         return []
 
+
+Schema(query=Person)
+
 [out]
 Success: no issues found in 1 source file
 
@@ -697,7 +794,7 @@ Success: no issues found in 1 source file
 [case test_resolver_with_correct_object_union_return_type_passes]
 from typing import List as ListType, Union
 
-from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull
+from graphene import ObjectType, Field, ResolveInfo, String, List, NonNull, Schema
 
 
 class AnimalModel:
@@ -726,6 +823,9 @@ class Person(ObjectType[PersonModel]):
     def resolve_pets(person: PersonModel, _: ResolveInfo) -> ListType[AnimalModel]:
         return []
 
+
+Schema(query=Person)
+
 [out]
 Success: no issues found in 1 source file
 
@@ -733,7 +833,7 @@ Success: no issues found in 1 source file
 [case test_resolver_with_mismatched_return_nullability_fails]
 from typing import List as ListType, Optional
 
-from graphene import ObjectType, Field, ResolveInfo, String
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
 
 
 class PersonModel:
@@ -747,13 +847,16 @@ class Person(ObjectType[PersonModel]):
     def resolve_name(person: PersonModel, _: ResolveInfo) -> Optional[str]:
         return ''
 
+
+Schema(query=Person)
+
 [out]
 main:14: error: Resolver returns type Union[builtins.str, None], expected type builtins.str
 Found 1 error in 1 file (checked 1 source file)
 
 
-[case test_resolver_with_scalar_type_is_correct]
-from graphene import ObjectType, Field, ResolveInfo, String
+[case test_resolver_with_correct_scalar_type_passes]
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
 from typing import Optional
 
 class A:
@@ -764,6 +867,216 @@ class TestQuery(ObjectType):
 
     def resolve_name(self, info: ResolveInfo, name: Optional[str]) -> None:
         return None
+
+[out]
+Success: no issues found in 1 source file
+
+
+[case test_resolver_with_incorrect_scalar_type_fails]
+from graphene import ObjectType, Field, ResolveInfo, String, Schema, List, NonNull
+from typing import Optional, List as ListType
+
+class A:
+    name: str
+
+class TestQuery(ObjectType):
+    name = Field(A, name=String(), other=String(required=True), some_list=NonNull(List(NonNull(String))))
+
+    def resolve_name(
+        self, info: ResolveInfo,
+        name: str, other: Optional[str], some_list: Optional[ListType[Optional[str]]],
+    ) -> None:
+        return None
+
+
+Schema(query=TestQuery)
+
+[out]
+main:10: error: Parameter "name" has type builtins.str, expected type Union[builtins.str, None]
+main:10: error: Parameter "other" has type Union[builtins.str, None], expected type builtins.str
+main:10: error: Parameter "some_list" has type Union[builtins.list[Union[builtins.str, None]], None], expected type builtins.list[builtins.str]
+Found 3 errors in 1 file (checked 1 source file)
+
+
+[case test_finds_errors_on_many_types_with_cycles]
+from graphene import ObjectType, Field, ResolveInfo, String, Schema, NonNull, List, Boolean, Schema
+from typing import Optional
+
+
+class BoardMember(ObjectType):
+    position = Field(String, required=True)
+
+    @staticmethod
+    def resolve_position(_: None, __: ResolveInfo) -> Optional[str]:
+        return None
+
+
+class Company(ObjectType):
+    company_name = Field(String, required=True)
+    employees = Field(List(NonNull(lambda: Employee)), required=True)
+    board_members = Field(List(NonNull(lambda: BoardMember)), required=True)
+
+    @staticmethod
+    def resolve_company_name(_: None, __: ResolveInfo) -> Optional[str]:
+        return None
+
+
+class Employee(ObjectType):
+    name = Field(String, required=True)
+    company = Field(Company, required=True)
+
+    @staticmethod
+    def resolve_name(_: None, __: ResolveInfo) -> Optional[str]:
+        return None
+
+
+class Boss(ObjectType):
+    employee = Field(Employee)
+
+
+class User(ObjectType):
+    username = Field(String, required=True)
+
+    @staticmethod
+    def resolve_username(_: None, __: ResolveInfo) -> int:
+        return 0
+
+
+class HiddenType(ObjectType):
+    is_hidden = Field(Boolean, required=True)
+
+    @staticmethod
+    def resolve_is_hidden(_: None, __: ResolveInfo) -> Optional[bool]:
+        return None
+
+
+class Query(ObjectType):
+    boss = Field(Boss)
+    user = Field(NonNull(User))
+
+
+class Mutations(ObjectType):
+    foo = Field(String)
+
+
+Schema(mutation=Mutations, query=Query, types=(HiddenType,))
+
+[out]
+main:9: error: Resolver returns type Union[builtins.str, None], expected type builtins.str
+main:19: error: Resolver returns type Union[builtins.str, None], expected type builtins.str
+main:28: error: Resolver returns type Union[builtins.str, None], expected type builtins.str
+main:40: error: Resolver returns type builtins.int, expected type builtins.str
+main:48: error: Resolver returns type Union[builtins.bool, None], expected type builtins.bool
+Found 5 errors in 1 file (checked 1 source file)
+
+
+[case test_multiple_schemas_only_errors_once]
+from typing import List as ListType, Optional
+
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
+
+
+class PersonModel:
+    name: Optional[str]
+
+
+class Person(ObjectType[PersonModel]):
+    name = Field(String, required=True)
+
+    @staticmethod
+    def resolve_name(person: PersonModel, _: ResolveInfo) -> Optional[str]:
+        return ''
+
+
+Schema(query=Person)
+Schema(query=Person)
+
+[out]
+main:14: error: Resolver returns type Union[builtins.str, None], expected type builtins.str
+Found 1 error in 1 file (checked 1 source file)
+
+
+[case test_resolver_for_field_subclass_passes]
+from graphene import ObjectType, Field, ResolveInfo, String, Schema
+from typing import Optional
+
+
+class CustomField(Field):
+    pass
+
+
+class ExtraCustomField(CustomField):
+    pass
+
+
+class TestQuery(ObjectType):
+    name = ExtraCustomField(String)
+
+    def resolve_name(self, info: ResolveInfo) -> None:
+        return None
+
+
+Schema(query=TestQuery)
+
+[out]
+Success: no issues found in 1 source file
+
+
+[case test_field_with_lambda_passes]
+from graphene import ObjectType, Field, ResolveInfo, String, Schema, NonNull
+from typing import Optional, Any
+import main
+
+
+class TestQuery(ObjectType):
+    my_thing = Field(NonNull(lambda: main.MyType))
+
+    def resolve_my_thing(self, info: ResolveInfo) -> Any:
+        return {}
+
+
+class MyType(ObjectType):
+    name = Field(String, required=True)
+
+
+Schema(query=TestQuery)
+
+[out]
+Success: no issues found in 1 source file
+
+
+[case test_field_with_argument_default_value_treated_as_non_null]
+from graphene import ObjectType, Field, ResolveInfo, String, Schema, Argument
+from typing import Optional, Any
+
+
+class TestQuery(ObjectType):
+    my_thing = Field(String, my_arg=Argument(String, default_value='foo'))
+
+    def resolve_my_thing(self, info: ResolveInfo, *, my_arg: Optional[str]) -> Optional[str]:
+        return my_arg
+
+
+Schema(query=TestQuery)
+
+[out]
+main:8: error: Parameter "my_arg" has type Union[builtins.str, None], expected type builtins.str
+Found 1 error in 1 file (checked 1 source file)
+
+
+[case test_field_with_argument_default_value_of_none_treated_as_nullable]
+from graphene import ObjectType, Field, ResolveInfo, String, Schema, Argument
+from typing import Optional, Any
+
+
+class TestQuery(ObjectType):
+    my_thing = Field(String, my_arg=Argument(String, default_value=None))
+
+    def resolve_my_thing(self, info: ResolveInfo, *, my_arg: Optional[str]) -> Optional[str]:
+        return my_arg
+
+
+Schema(query=TestQuery)
 
 [out]
 Success: no issues found in 1 source file


### PR DESCRIPTION
This PR completely re-works the graphene plugin to work more similarly to the way mypy itself works.

Work is done in two passes. The first pass is done at semantic analysis time and the nature of that work just involves figuring out the types of various things and building a data model containing those types that can be used at type-checking time.

The second pass is done at type-checking time. The data model that was built during semantic analysis is then used to check types and submit errors when the types are not correct.

I ended up rewriting things quite a bit to incorporate all my newest learnings about how mypy works, how the AST is structured, and how graphene works. For example, there are no more `type: ignore` comments or `getattr()` calls! However, being more/less a rewrite, the diff is quite ugly. I would just read over all the code fresh. I've also heavily documented the code so hopefully it's easier to understand and easier for others to contribute!

And of course, now that the type-checking is happening at type-checking time we can build more useful typechecks that rely on full semantic analysis having been previously performed.