### PR TITLE
Add more flexibility when looking for graphene defs

### DIFF
--- a/test/test-data/unit/graphene_plugin.test
+++ b/test/test-data/unit/graphene_plugin.test
@@ -1158,3 +1158,40 @@ class Person(ObjectType[PersonModel]):
 [out]
 main:12: error: "PersonModel" has no attribute "first_name"
 Found 1 error in 1 file (checked 1 source file)
+
+
+[case test_field_resolve_with_namespace]
+from typing import Optional
+
+import graphene
+
+
+class TestQuery(graphene.ObjectType):
+    field = graphene.Field(graphene.String)
+
+    @staticmethod
+    def resolve_field(_: None, __: graphene.ResolveInfo) -> Optional[str]:
+        return 'hi'
+
+
+[out]
+Success: no issues found in 1 source file
+
+
+[case test_field_resolve_with_namespace_fails]
+from typing import Optional
+
+import graphene
+
+
+class TestQuery(graphene.ObjectType):
+    field = graphene.Field(graphene.Int)
+
+    @staticmethod
+    def resolve_field(_: None, __: graphene.ResolveInfo) -> Optional[str]:
+        return 'hi'
+
+
+[out]
+main:10: error: Resolver returns type Union[builtins.str, None], expected type Union[builtins.int, None]
+Found 1 error in 1 file (checked 1 source file)


### PR DESCRIPTION
We were doing a lot of checking if things were `NameExpr`s because we were looking for statements like `Field`. However, that wouldn't match something like `graphene.Field` because that's a `MemberExpr`, not a `NameExpr`. What we _really_ should've been checking for is if something is a `RefExpr` (the ABC that both `NameExpr` and `MemberExpr` implement.) That ABC contains all the data we need to do our checks!

Fixes #16 