### PR TITLE
Revert part of enum changes

### DIFF
--- a/graphene-stubs/types/enum.pyi
+++ b/graphene-stubs/types/enum.pyi
@@ -56,12 +56,3 @@ class Enum(UnmountedType, BaseType, metaclass=EnumMeta):
     @classmethod
     def get_type(cls) -> Any:
         ...
-
-    @classmethod
-    def from_enum(
-        cls,
-        enum: Type[PyEnum],
-        desciption: Optional[str] = ...,
-        deprecation_reason: Optional[str] = ...,
-    ) -> EnumMeta:
-        ...


### PR DESCRIPTION
Adding this method definition doesn't seem necessary as it exists on the metaclass already. With this change, all the tests still pass, and all the new enum errors in the spark repo disappear again!