### PR TITLE
Don't type-check Interface fields as if they were defined on the ObjectType

### DIFF
--- a/test/test-data/unit/graphene_plugin.test
+++ b/test/test-data/unit/graphene_plugin.test
@@ -1349,3 +1349,30 @@ class Employee(ObjectType[PersonModel]):
 [out]
 Success: no issues found in 1 source file 
 
+
+[case test_default_resolver_check_does_not_run_on_interface_fields]
+from typing import Optional, List as ListType, Type
+
+from graphene import Interface, Field, ResolveInfo, Argument, Boolean, Int, String, ObjectType
+
+
+class PersonModel:
+    name: str
+
+
+class Person(Interface[PersonModel]):
+    name = Field(String, required=True)
+    age = Field(Int, required=True)
+
+    @staticmethod
+    def resolve_age(_: PersonModel, __: ResolveInfo) -> int:
+        return 28 
+
+
+class Employee(ObjectType[PersonModel]):
+    class Meta:
+        interfaces = (Person,)
+
+
+[out]
+Success: no issues found in 1 source file 


### PR DESCRIPTION
The plugin used to take all of an `ObjectType`s' `Interface`s' `Field()`s and just include them as if they were defined on the `ObjectType` itself. The reason for doing this is that, we were looping over an `ObjectType`'s `Field()`s, finding the corresponding resolver, and checking that the resolver's type annotations were correct, but there is a common usecase where the `Field()` is defined on an `Interface`, but the _resolver_ is defined on the `ObjectType`. So in order to get the checking to work, we were including `Field()`s defined on the `ObjectType`'s `Interface`s when looping through the `Field()`s.

But this created a problem when I recently added support for type-checking `Field()`s that have no explicit resolver defined. Because we were copying the `Interface`'s `Field()`s to the `ObjectType()`, we were creating a situation where it _looked_ like an `ObjectType` had fields without explicit resolvers defined, but really those `Field()`s were just copied from an `Interface` (and the resolver was defined on the `Interface`.)

I will detail the strategy I employed to fix this bug inline: